### PR TITLE
Fix for the ceSimReco crash in recent CI jobs.

### DIFF
--- a/Validation/ceSimReco.fcl
+++ b/Validation/ceSimReco.fcl
@@ -40,7 +40,7 @@ physics: {
     @sequence::Common.generateSequence,
     @sequence::Common.g4Sequence,
     @sequence::Primary.PrimarySequence,
-    @sequence::Digitize.TriggerPath,
+    @sequence::Digitize.DigitizePath,
     @sequence::Reconstruction.CaloReco,
     @sequence::Reconstruction.TrkReco,
     @sequence::Reconstruction.CrvReco,
@@ -66,7 +66,7 @@ outputs : {
      outputCommands : [
 	 @sequence::Reconstruction.HighRecoProducts,
 	 @sequence::Reconstruction.MCRecoProducts,
-	 @sequence::Digitize.KeptProducts,
+	 @sequence::Digitize.DigiProducts,
 	 @sequence::Primary.KeptProducts,
 	 # drop reco products which be empty
 	 "drop mu2e::Crv*_*_*_*",


### PR DESCRIPTION
Recent Offline CI jobs, for example https://github.com/Mu2e/Offline/pull/474 , have failures in ceSimReco and in cEmix.

This PR fixes the failure in ceSimReco - changes in JobConfig were not propagated to Validation.

I am 99% sure that the crash in ceMix is because the default input filename for the mix-in files is now @nil.  So we need to provide real values in Valication/ceMix.fcl.

I am done for the day and can look at it tomorrow if no one else get's there first.
