### PR TITLE
Removed unused fcl imports, using common sequences

### DIFF
--- a/JobConfig/cosmic/S1DSStops.fcl
+++ b/JobConfig/cosmic/S1DSStops.fcl
@@ -2,7 +2,10 @@
 // Cosmics hitting crvStage1End volumes are stopped and saved for later resampling.
 //
 // Yuri Oksuzian, 2021
+#include "fcl/standardServices.fcl"
+#include "JobConfig/common/prolog.fcl"
 #include "JobConfig/primary/prolog.fcl"
+#include "JobConfig/cosmic/prolog.fcl"
 
 process_name : Primary
 
@@ -10,13 +13,12 @@ services: @local::Services.Sim
 
 physics: {
   producers : {
-    g4run : @local::mu2e.physics.producers.g4run.muons
-    genCounter: { module_type: GenEventCounter }
     compressPV: @local::Cosmic.compressPV
+    @table::Common.producers
   }
 
   filters : {
-    g4status: @local::Cosmic.g4status
+    @table::Common.filters
     stepPointMomentumFilter : @local::Cosmic.stepPointMomentumFilter
     cosmicFilter : @local::Cosmic.cosmicFilter
   }
@@ -25,7 +27,7 @@ physics: {
     genCountLogger: { module_type: GenEventCountReader makeHistograms: false }
   }
 
-  TriggerPath :  [generate, genCounter, g4run, g4status, stepPointMomentumFilter, cosmicFilter, compressPV]
+  PrimaryPath :  [@sequence::Common.generateSequence, @sequence::Common.g4Sequence, stepPointMomentumFilter, cosmicFilter, compressPV]
   EndPath : @local::Primary.EndPath
 
 }
@@ -41,7 +43,9 @@ physics.producers.g4run.Mu2eG4CommonCut: @local::Cosmic.Mu2eG4CommonCutCosmicS1
 #
 # final configuration
 #
+#include "JobConfig/common/epilog.fcl"
 #include "JobConfig/primary/epilog.fcl"
+
 physics.end_paths : [ EndPath ]
 # no histogram output
 services.TFileService.fileName : "/dev/null"


### PR DESCRIPTION
This PR fixes the fcl file for CRY and CORSIKA production. It removes unused fcl imports and uses the `Common` sequences in the paths. 