### PR TITLE
MT version of resamplers

### DIFF
--- a/JobConfig/beam/BeamResampler_MT.fcl
+++ b/JobConfig/beam/BeamResampler_MT.fcl
@@ -1,0 +1,6 @@
+# MT version of ProtonsOnTarget
+#include "JobConfig/beam/BeamResampler.fcl"
+
+physics.producers.g4run.module_type : "Mu2eG4MT"
+services.scheduler.num_schedules : 2
+services.scheduler.num_threads   : 2

--- a/JobConfig/beam/BeamResampler_MT.fcl
+++ b/JobConfig/beam/BeamResampler_MT.fcl
@@ -1,4 +1,4 @@
-# MT version of ProtonsOnTarget
+# MT version of BeamResampler
 #include "JobConfig/beam/BeamResampler.fcl"
 
 physics.producers.g4run.module_type : "Mu2eG4MT"

--- a/JobConfig/beam/NeutralsResampler_MT.fcl
+++ b/JobConfig/beam/NeutralsResampler_MT.fcl
@@ -1,4 +1,4 @@
-# MT version of ProtonsOnTarget
+# MT version of NeutralsResampler
 #include "JobConfig/beam/NeutralsResampler.fcl"
 
 physics.producers.g4run.module_type : "Mu2eG4MT"

--- a/JobConfig/beam/NeutralsResampler_MT.fcl
+++ b/JobConfig/beam/NeutralsResampler_MT.fcl
@@ -1,0 +1,6 @@
+# MT version of ProtonsOnTarget
+#include "JobConfig/beam/NeutralsResampler.fcl"
+
+physics.producers.g4run.module_type : "Mu2eG4MT"
+services.scheduler.num_schedules : 2
+services.scheduler.num_threads   : 2

--- a/JobConfig/beam/POT_MT.fcl
+++ b/JobConfig/beam/POT_MT.fcl
@@ -1,3 +1,6 @@
 # MT version of ProtonsOnTarget
-#include "JobConfig/beam/ProtonsOnTarget.fcl"
-#include "JobConfig/common/epilog_MT.fcl"
+#include "JobConfig/beam/POT.fcl"
+
+physics.producers.g4run.module_type : "Mu2eG4MT"
+services.scheduler.num_schedules : 2
+services.scheduler.num_threads   : 2

--- a/JobConfig/common/epilog_MT.fcl
+++ b/JobConfig/common/epilog_MT.fcl
@@ -1,8 +1,0 @@
-#
-#  epilog to transform a serial Mu2eG4 job into a Mu2eG4MT job
-#  content from Lisa Goodenough
-#
-physics.producers.g4run.module_type : "Mu2eG4MT"
-physics.producers.g4run.maxEventsToSeed              : 20000
-services.scheduler.num_schedules : 5
-services.scheduler.num_threads   : 5


### PR DESCRIPTION
This PR includes the MT version of `BeamResampler` and `NeutralsResampler`. The MT parameters are specified explicitly and the `epilog_MT.fcl` file is removed. 