### PR TITLE
Add artcatSplitLevel1.fcl

### DIFF
--- a/JobConfig/common/artcatSplitLevel1.fcl
+++ b/JobConfig/common/artcatSplitLevel1.fcl
@@ -7,7 +7,7 @@
 
 #include "Offline/fcl/minimalMessageService.fcl"
 
-process_name: unsplit
+process_name: artcatSplitLevel1
 source: { module_type: RootInput }
 services: { message: @local::default_message }
 physics: { e1: [out]  end_paths: [e1] }

--- a/JobConfig/common/unsplit.fcl
+++ b/JobConfig/common/unsplit.fcl
@@ -1,0 +1,13 @@
+// Analog of artcat.fcl but write the output file with splitLevel : 1
+//
+// See comments in ./artcat.fcl
+//
+// Rob Kutschke, 2021
+
+#include "Offline/fcl/minimalMessageService.fcl"
+
+process_name: unsplit
+source: { module_type: RootInput }
+services: { message: @local::default_message }
+physics: { e1: [out]  end_paths: [e1] }
+outputs: { out: { module_type: RootOutput fileName: @nil splitLevel: 1 } }

--- a/JobConfig/common/unsplit.fcl
+++ b/JobConfig/common/unsplit.fcl
@@ -1,4 +1,5 @@
 // Analog of artcat.fcl but write the output file with splitLevel : 1
+// This will write each data product as an unsplit unit.
 //
 // See comments in ./artcat.fcl
 //


### PR DESCRIPTION
The script artcatSplitLevel1.fcl behaves like artcat.fcl but it writes the output file with splitLevel : 1.  Previous code used the default, which is splitLevel : 99.  This means fully split since our most nested data products are about 5 or 6 levels deep.

The effect of this change is that the data product payload ( the .obj branch inside the root file) unspilt unit.  

According to Chris Jone, CMS uses splitLevel : 1 if the output is intended to be ready by a production job and they make fully split files if the file is intended to be used for analysis.  The reason is that it saves memory in the running jobs at the cost of increased size on disk.

I tested a MuminusStops file from MDC2020d.  There was an increase in size on disk of 4.2%.  I have not tested the memory savings.