### PR TITLE
Save only parent and direct SimParticles in pileup

### DIFF
--- a/JobConfig/pileup/prolog.fcl
+++ b/JobConfig/pileup/prolog.fcl
@@ -8,7 +8,10 @@ Pileup: {
   # override compression to be more selective
     compressDetStepMCs: {
       stepPointMCTags : [ ] # turn off VD hits for pileup
-      compressionOptions : @local::DetStepCompression.extraCompression # remove some intermediate genealogy steps
+      compressionOptions : {
+	@table::DetStepCompression.extraCompression # remove some intermediate genealogy steps
+	keepNGenerations : 1 # only keep SimParticles producing DetectorSteps and their direct parents
+      }
       mcTrajectoryTag : "" # no MC Trajectories
     }
   }

--- a/MDC2020/gen_BeamResampler.sh
+++ b/MDC2020/gen_BeamResampler.sh
@@ -1,9 +1,0 @@
-generate_fcl --dsconf=MDC2020$1 --dsowner=brownd --run-number=1202 --description=BeamResampler --events-per-job=200000 --njobs=1000 --include JobConfig/beam/BeamResampler.fcl --auxinput=1:physics.filters.beamResampler.fileNames:Beami$1.txt
-for dirname in 000 001 002 003 004 005 006 007 008 009; do
- if test -d $dirname; then
-  echo "found dir $dirname"
-  rm -rf BeamResampler$1_$dirname
-  mv $dirname BeamResampler$1_$dirname
- fi
-done
-


### PR DESCRIPTION
This change will eventually change the content of mixin samples, but won't have any immediate effect on nightly validation.