### PR TITLE
Complete the undoing of PR #99

### DIFF
--- a/JobConfig/beam/prolog.fcl
+++ b/JobConfig/beam/prolog.fcl
@@ -221,7 +221,7 @@ Beam: {
          { type: plane normal: [ -1, 0, 0 ] point : [ 2800., 0, 0 ] },
 
          // Make sure the charged particle beam reaches our DS2Vacuum stopping volume
-         {type: notInVolume pars:[TS2Vacuum, TS3Vacuum, TS4Vacuum, TS5Vacuum, Coll31, Coll32, Coll51, TS2InnerCryoShell, TS3InnerCryoShell, TS4InnerCryoShell, TS2CryoInsVac, TS3CryoInsVac, VirtualDetector_Coll31_In, VirtualDetector_Coll32_In, VirtualDetector_Coll31_Out, VirtualDetector_Coll32_Out, Coll31OutRecord, Coll32InRecord, Coll31OutRecord, VirtualDetector_TS4_Bend, VirtualDetector_Coll5_In, VirtualDetector_Coll5_Out, VirtualDetector_Coll5_OutSurf]},
+         {type: notInVolume pars:[TS2Vacuum, TS3Vacuum, TS4Vacuum, TS5Vacuum, Coll31, Coll32, Coll51, TS2InnerCryoShell, TS3InnerCryoShell, TS4InnerCryoShell, TS2CryoInsVac, TS3CryoInsVac, PbarAbsDisk, PbarAbsWedge, VirtualDetector_Coll31_In, VirtualDetector_Coll32_In, VirtualDetector_Coll31_Out, VirtualDetector_Coll32_Out, Coll31OutRecord, Coll32InRecord, Coll31OutRecord, VirtualDetector_TS4_Bend, VirtualDetector_Coll5_In, VirtualDetector_Coll5_Out, VirtualDetector_Coll5_OutSurf]},
 
          // This union splits the output of the above cuts
          // into two exclusive streams; Beam (charged particles entering the DS) and Neutrals ((mostly)neutral particles approaching the CRV

--- a/JobConfig/cosmic/geom_cosmic.txt
+++ b/JobConfig/cosmic/geom_cosmic.txt
@@ -8,7 +8,7 @@ double world.minimalMargin.xmax = 500000;
 double world.minimalMargin.zmin = 500000;
 double world.minimalMargin.zmax = 500000;
 
-// string dirt.beamline.berm.material = "G4_AIR";
+string dirt.beamline.berm.material = "G4_AIR";
 
 //
 // This tells emacs to view this file in c++ mode.

--- a/JobConfig/cosmic/geom_cosmic_current.txt
+++ b/JobConfig/cosmic/geom_cosmic_current.txt
@@ -8,7 +8,7 @@ double world.minimalMargin.xmax = 500000;
 double world.minimalMargin.zmin = 500000;
 double world.minimalMargin.zmax = 500000;
 
-// string dirt.beamline.berm.material = "G4_AIR";
+string dirt.beamline.berm.material = "G4_AIR";
 
 //
 // This tells emacs to view this file in c++ mode.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,2 @@
 # Production
 Scripts and fcl for collaboration production procedures
-


### PR DESCRIPTION
This commit brings the head of main back to the state that it was at commit 742a9d2d, which is the merge of PR#101.   It completes the undo of #99 that was only partially fixed by PR #103 .   After merging this PR, the head should diff cleanly against commit 742a9d2d .

It took 2 mistakes to get here.  PR #99 was  dummy for testing.  The first mistake was that it started from branch Mu2eII_SM21 but I asked to merge it into main.  The second mistake was to merge it, not close it.

In addition to the intended dummy change to README.md PR #99 inadvertently included changes to 3 files:

JobConfig/beam/prolog.fcl
JobConfig/cosmic/geom_cosmic.txt
JobConfig/cosmic/geom_cosmic_current.txt





