### PR TITLE
Add source to CRY and DYB fcl files

### DIFF
--- a/JobConfig/cosmic/S1DSStopsCRY.fcl
+++ b/JobConfig/cosmic/S1DSStopsCRY.fcl
@@ -1,4 +1,5 @@
 #include "Production/JobConfig/cosmic/S1DSStops.fcl"
 
+source.module_type: EmptyEvent
 physics.producers.generate : @local::Cosmic.generateCRY
 outputs.Output.fileName : "sim.owner.CosmicDSStopsCRY.version.sequencer.art"

--- a/JobConfig/cosmic/S1DSStopsDYB.fcl
+++ b/JobConfig/cosmic/S1DSStopsDYB.fcl
@@ -1,4 +1,5 @@
 #include "Production/JobConfig/cosmic/S1DSStops.fcl"
 
+source.module_type: EmptyEvent
 physics.producers.generate.inputfile    : "Production/JobConfig/cosmic/genconfig_cosmic_general_box.txt"
 physics.producers.generate.module_type  : EventGenerator


### PR DESCRIPTION
This PR contains a small fix to the CRY and DYB stage 1 files. They were missing the `source.module_type: EmptyEvent`. However I am not sure why they were working before and when they stopped working. 