### PR TITLE
No multiple subruns for cosmic resampling

### DIFF
--- a/JobConfig/cosmic/prolog.fcl
+++ b/JobConfig/cosmic/prolog.fcl
@@ -129,6 +129,7 @@ Cosmic: {
     mu2e: {
       writeEventIDs : true
       MaxEventsToSkip: @nil
+      resampleMultipleSubruns: false
       products: {
         genParticleMixer: { mixingMap: [ [ "generate", "" ] ] }
         simParticleMixer: { mixingMap: [ [ "cosmicFilter", ""] ] }


### PR DESCRIPTION
Added flag to cosmic prolog which enforces only one subrun per job for cosmic resampling. Needs https://github.com/Mu2e/Offline/pull/633. 