### PR TITLE
Explicitly declare end_path sequence

### DIFF
--- a/JobConfig/digitize/OffSpill.fcl
+++ b/JobConfig/digitize/OffSpill.fcl
@@ -7,5 +7,6 @@
 physics.producers.EWMProducer.SpillType : 0
 # keep all streams
 physics.EndPath : [ @sequence::Digitize.EndSequence, SignalOutput, DiagOutput, TrkOutput, CaloOutput, UntriggeredOutput ]
+physics.end_paths : [ EndPath ]
 # override the untriggered filter
 physics.filters.UntriggeredPrescale.prescaleFactor : 1 # record 100% of the untriggered

--- a/JobConfig/digitize/OnSpill.fcl
+++ b/JobConfig/digitize/OnSpill.fcl
@@ -9,5 +9,6 @@
 physics.producers.EWMProducer.SpillType : 1
 # keep all streams
 physics.EndPath : [ @sequence::Digitize.EndSequence, SignalOutput, DiagOutput, TrkOutput, CaloOutput, UntriggeredOutput ]
+physics.end_paths : [ EndPath ]
 # override the untriggered filter
 physics.filters.UntriggeredPrescale.prescaleFactor : 10 # record 10% of the untriggered


### PR DESCRIPTION
This fixes the incompatibility of OnSpill and OffSpill digitization with generate_fcl