### PR TITLE
Moving from IPAStopResampler to  IPAMuminusStopResampler

### DIFF
--- a/JobConfig/primary/IPAMuminusFlateMinus.fcl
+++ b/JobConfig/primary/IPAMuminusFlateMinus.fcl
@@ -1,21 +1,20 @@
 #
 # Configuration for resampling IPA muon stops and generating primary particles from them
-# with Michel spectrum
+# with flat spectrum
 #
 # original author: S Middleton
 #
 #include "Production/JobConfig/primary/IPAStopParticle.fcl"
 
 physics.filters.DetStepFilter.MinimumPartMom : 10.0 // MeV/c TODO - tweak this parameter to get more DetSteps
-physics.producers.FindMCPrimary.PrimaryProcess : "mu2eMuonDecayAtRest"
+physics.producers.FindMCPrimary.PrimaryProcess : "mu2eFlateMinus"
 
 physics.producers.generate : {
-  module_type : Pileup
-  verbosity : 10
-  inputSimParticles: IPAStopResampler
-  captureProducts : []
-  decayProducts : [ @local::Pileup.dioGenTool ]
+  module_type: FlatMuonDaughterGenerator
+  inputSimParticles: IPAMuminusStopResampler
   stoppingTargetMaterial : "IPA"
+  verbosity : 1
+  pdgId : 11
 }
 
-outputs.PrimaryOutput.fileName: "dts.owner.IPAMichel.version.sequencer.art"
+outputs.PrimaryOutput.fileName: "dts.owner.IPAMuminusFlateMinus.version.sequencer.art"

--- a/JobConfig/primary/IPAMuminusMichel.fcl
+++ b/JobConfig/primary/IPAMuminusMichel.fcl
@@ -1,20 +1,21 @@
 #
 # Configuration for resampling IPA muon stops and generating primary particles from them
-# with flat spectrum
+# with Michel spectrum
 #
 # original author: S Middleton
 #
 #include "Production/JobConfig/primary/IPAStopParticle.fcl"
 
 physics.filters.DetStepFilter.MinimumPartMom : 10.0 // MeV/c TODO - tweak this parameter to get more DetSteps
-physics.producers.FindMCPrimary.PrimaryProcess : "mu2eFlateMinus"
+physics.producers.FindMCPrimary.PrimaryProcess : "mu2eMuonDecayAtRest"
 
 physics.producers.generate : {
-  module_type: FlatMuonDaughterGenerator
-  inputSimParticles: IPAStopResampler
+  module_type : Pileup
+  verbosity : 10
+  inputSimParticles: IPAMuminusStopResampler
+  captureProducts : []
+  decayProducts : [ @local::Pileup.dioGenTool ]
   stoppingTargetMaterial : "IPA"
-  verbosity : 1
-  pdgId : 11
 }
 
-outputs.PrimaryOutput.fileName: "dts.owner.IPAFlat.version.sequencer.art"
+outputs.PrimaryOutput.fileName: "dts.owner.IPAMuminusMichel.version.sequencer.art"

--- a/JobConfig/primary/IPAStopParticle.fcl
+++ b/JobConfig/primary/IPAStopParticle.fcl
@@ -5,14 +5,14 @@
 #
 #include "Production/JobConfig/primary/StopParticle.fcl"
 
-physics.PrimaryPath : [ IPAStopResampler, @sequence::Common.generateSequence, @sequence::Common.g4Sequence, @sequence::Primary.PrimarySequence ]
+physics.PrimaryPath : [ IPAMuminusStopResampler, @sequence::Common.generateSequence, @sequence::Common.g4Sequence, @sequence::Primary.PrimarySequence ]
 physics.trigger_paths : [ PrimaryPath ]
 outputs : { PrimaryOutput :@local::Primary.PrimaryOutput }
 physics.EndPath : [ @sequence::Primary.EndSequence, PrimaryOutput ]
 physics.end_paths : [ EndPath ]
 
-physics.producers.g4run.inputs.inputPhysVolumeMultiInfo: "IPAStopResampler"
+physics.producers.g4run.inputs.inputPhysVolumeMultiInfo: "IPAMuminusStopResampler"
 physics.producers.g4run.inputs.updateEventLevelVolumeInfos: {
-  input: "IPAStopResampler:eventlevel"
+  input: "IPAMuminusStopResampler:eventlevel"
   outInstance: "eventlevel"
 }

--- a/JobConfig/primary/prolog.fcl
+++ b/JobConfig/primary/prolog.fcl
@@ -101,7 +101,7 @@ Primary: {
       }
     }
 
-    IPAStopResampler : {
+    IPAMuminusStopResampler : {
       module_type: ResamplingMixer
       readMode            : sequential
       wrapFiles           : true

--- a/Tests/IPAFlatSteps.fcl
+++ b/Tests/IPAFlatSteps.fcl
@@ -1,13 +1,13 @@
 #include "Production/JobConfig/primary/IPAStopsFlat.fcl"
 source.firstRun: 501 #TODO
-physics.filters.IPAStopResampler.fileNames : [
+physics.filters.IPAMuminusStopResampler.fileNames : [
   "/pnfs/mu2e/scratch/datasets/phy-sim/sim/mu2e/IPAStopsCat/MDC2020i/art/6b/10/sim.mu2e.IPAStopsCat.MDC2020i.001202_00000000.art"
   //"root://fndca1.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/scratch/datasets/phy-sim/sim/mu2e/IPAStopsCat/MDC2020i/art/6b/10/sim.mu2e.IPAStopsCat.MDC2020i.001202_00000000.art"
 ]
 
 physics.producers.generate.startMom : 0
 physics.producers.generate.endMom : 100
-physics.filters.IPAStopResampler.mu2e.MaxEventsToSkip: 4143
+physics.filters.IPAMuminusStopResampler.mu2e.MaxEventsToSkip: 4143
 outputs.Output.fileName : "dts.tester.IPAFlat.Test.1.art"
 services.scheduler.wantSummary: true
 services.TFileService.fileName: "nts.owner.IPAFlatGen.version.sequencer.root"

--- a/Tests/IPAFlatSteps.fcl
+++ b/Tests/IPAFlatSteps.fcl
@@ -1,13 +1,12 @@
 #include "Production/JobConfig/primary/IPAStopsFlat.fcl"
 source.firstRun: 501 #TODO
 physics.filters.IPAMuminusStopResampler.fileNames : [
-  "/pnfs/mu2e/scratch/datasets/phy-sim/sim/mu2e/IPAStopsCat/MDC2020i/art/6b/10/sim.mu2e.IPAStopsCat.MDC2020i.001202_00000000.art"
-  //"root://fndca1.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/scratch/datasets/phy-sim/sim/mu2e/IPAStopsCat/MDC2020i/art/6b/10/sim.mu2e.IPAStopsCat.MDC2020i.001202_00000000.art"
+  "/pnfs/mu2e/tape/phy-sim/sim/mu2e/IPAMuminusStopsCat/MDC2020r/art/45/08/sim.mu2e.IPAMuminusStopsCat.MDC2020r.001201_00000000.art"
 ]
 
 physics.producers.generate.startMom : 0
 physics.producers.generate.endMom : 100
-physics.filters.IPAMuminusStopResampler.mu2e.MaxEventsToSkip: 4143
+physics.filters.IPAMuminusStopResampler.mu2e.MaxEventsToSkip: 18875
 outputs.Output.fileName : "dts.tester.IPAFlat.Test.1.art"
 services.scheduler.wantSummary: true
 services.TFileService.fileName: "nts.owner.IPAFlatGen.version.sequencer.root"

--- a/Tests/IPAFlatSteps.fcl
+++ b/Tests/IPAFlatSteps.fcl
@@ -1,4 +1,4 @@
-#include "Production/JobConfig/primary/IPAStopsFlat.fcl"
+#include "Production/JobConfig/primary/IPAMuminusFlateMinus.fcl"
 source.firstRun: 501 #TODO
 physics.filters.IPAMuminusStopResampler.fileNames : [
   "/pnfs/mu2e/tape/phy-sim/sim/mu2e/IPAMuminusStopsCat/MDC2020r/art/45/08/sim.mu2e.IPAMuminusStopsCat.MDC2020r.001201_00000000.art"
@@ -7,6 +7,6 @@ physics.filters.IPAMuminusStopResampler.fileNames : [
 physics.producers.generate.startMom : 0
 physics.producers.generate.endMom : 100
 physics.filters.IPAMuminusStopResampler.mu2e.MaxEventsToSkip: 18875
-outputs.Output.fileName : "dts.tester.IPAFlat.Test.1.art"
+outputs.Output.fileName : "dts.tester.IPAMuminusFlateminus.Test.1.art"
 services.scheduler.wantSummary: true
 services.TFileService.fileName: "nts.owner.IPAFlatGen.version.sequencer.root"

--- a/Tests/IPAMichelSteps.fcl
+++ b/Tests/IPAMichelSteps.fcl
@@ -1,10 +1,10 @@
 #include "Production/JobConfig/primary/IPAStopsMichel.fcl"
 source.firstRun: 501 #TODO
-physics.filters.IPAStopResampler.fileNames : [
+physics.filters.IPAMuminusStopResampler.fileNames : [
   //"/pnfs/mu2e/scratch/datasets/phy-sim/sim/mu2e/IPAStopsCat/MDC2020i/art/6b/10/sim.mu2e.IPAStopsCat.MDC2020i.001202_00000000.art"
   "root://fndca1.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/scratch/datasets/phy-sim/sim/mu2e/IPAStopsCat/MDC2020i/art/6b/10/sim.mu2e.IPAStopsCat.MDC2020i.001202_00000000.art"
 ]
-physics.filters.IPAStopResampler.mu2e.MaxEventsToSkip: 4143
+physics.filters.IPAMuminusStopResampler.mu2e.MaxEventsToSkip: 4143
 outputs.Output.fileName : "dts.tester.IPAMichel.Test.1.art"
 services.scheduler.wantSummary: true
 services.TFileService.fileName: "nts.owner.IPAgen.version.sequencer.root"

--- a/Tests/IPAMichelSteps.fcl
+++ b/Tests/IPAMichelSteps.fcl
@@ -1,10 +1,9 @@
 #include "Production/JobConfig/primary/IPAStopsMichel.fcl"
 source.firstRun: 501 #TODO
 physics.filters.IPAMuminusStopResampler.fileNames : [
-  //"/pnfs/mu2e/scratch/datasets/phy-sim/sim/mu2e/IPAStopsCat/MDC2020i/art/6b/10/sim.mu2e.IPAStopsCat.MDC2020i.001202_00000000.art"
-  "root://fndca1.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/scratch/datasets/phy-sim/sim/mu2e/IPAStopsCat/MDC2020i/art/6b/10/sim.mu2e.IPAStopsCat.MDC2020i.001202_00000000.art"
+  "/pnfs/mu2e/tape/phy-sim/sim/mu2e/IPAMuminusStopsCat/MDC2020r/art/45/08/sim.mu2e.IPAMuminusStopsCat.MDC2020r.001201_00000000.art"
 ]
-physics.filters.IPAMuminusStopResampler.mu2e.MaxEventsToSkip: 4143
+physics.filters.IPAMuminusStopResampler.mu2e.MaxEventsToSkip: 18875
 outputs.Output.fileName : "dts.tester.IPAMichel.Test.1.art"
 services.scheduler.wantSummary: true
 services.TFileService.fileName: "nts.owner.IPAgen.version.sequencer.root"

--- a/Tests/IPAMichelSteps.fcl
+++ b/Tests/IPAMichelSteps.fcl
@@ -1,9 +1,9 @@
-#include "Production/JobConfig/primary/IPAStopsMichel.fcl"
+#include "Production/JobConfig/primary/IPAMuminusMichel.fcl"
 source.firstRun: 501 #TODO
 physics.filters.IPAMuminusStopResampler.fileNames : [
   "/pnfs/mu2e/tape/phy-sim/sim/mu2e/IPAMuminusStopsCat/MDC2020r/art/45/08/sim.mu2e.IPAMuminusStopsCat.MDC2020r.001201_00000000.art"
 ]
 physics.filters.IPAMuminusStopResampler.mu2e.MaxEventsToSkip: 18875
-outputs.Output.fileName : "dts.tester.IPAMichel.Test.1.art"
+outputs.Output.fileName : "dts.tester.IPAMuminusMichel.Test.1.art"
 services.scheduler.wantSummary: true
 services.TFileService.fileName: "nts.owner.IPAgen.version.sequencer.root"


### PR DESCRIPTION
This PR changes the IPA fcl file to be compatible with the new stream where we split the Muminus and Muplus of the IPA output. 