### PR TITLE
Cosmicsplit

### DIFF
--- a/JobConfig/cosmic/SpillSplitter.fcl
+++ b/JobConfig/cosmic/SpillSplitter.fcl
@@ -1,6 +1,6 @@
 #
-# split cosmic primarys prior to OnSpill or OffSpill digitization.  OnSpill (mixing)
-# requires there be a signal-like particle, Offspill is simply prescaled
+# select cosmic primarys for digitization.  OnSpill (mixing) requires a signal
+# or calibration-like track, # Offspill is simply prescaled
 #
 #include "Offline/fcl/standardServices.fcl"
 #include "Production/JobConfig/common/prolog.fcl"
@@ -12,36 +12,22 @@ services.SeedService.baseSeed : @local::Common.BaseSeed
 physics: {
   filters : {
     OnSpillSignalFilter : { # select particles in the Ce signal momentum band, with no cut on the hits
-      module_type : DetectorStepFilter
-      CaloShowerSteps : [ ]  # don't allow calo clusters themselves to pass
-      CrvSteps : [ ] # dont filter on CRV since that can't trigger
-      StrawGasSteps : [ "compressDetStepMCs" ]
-      KeepPDG : [ ] # Loop at steps from all particle types
-      #      KeepPDG : [ 11,-11, 13, -13] # e+-, mu+-
-      MinimumPartMom : 80
-      MaximumPartMom : 120
-      MinimumTrkSteps : 20
-      #      TimeCutConfig : {
-      #        MinimumTime : 400
-      #        MaximumTime : 1700
-      #      }
-    }
-    OnSpillCalibFilter : { # select particles with many hits (large multi-loop helices)
-      module_type : DetectorStepFilter
-      CaloShowerSteps : [ ]  # don't allow calo clusters themselves to pass
-      CrvSteps : [ ] # dont filter on CRV since that can't trigger
-      StrawGasSteps : [ "compressDetStepMCs" ]
-      KeepPDG : [ ] # Loop at steps from all particle types
-      MinimumPartMom : 45
+      # this selection is 100% efficient for Ces, and accepts 98% of cosmics
+      # which pass an OnSpill triggers
+      module_type : CosmicMixingFilter
+      StrawGasSteps : "compressDetStepMCs"
+      MinimumPartMom : 50
       MaximumPartMom : 250
-      MinimumTrkSteps: 60
+      MinimumTrkSteps : 15
+      MinimumTrkPlanes : 7
+      MinimumTrkPlaneSpan : 18
+      MaxImpact : 250.0
     }
-
   }
+  # Eventually add calibration paths and OffSpill paths TODO
   OnSpillSignalPath : [OnSpillSignalFilter ]
-  OnSpillCalibPath : [OnSpillCalibFilter ]
-  trigger_paths : [ OnSpillSignalPath, OnSpillCalibPath ]
-  outpath: [ OnSpillOutput ]
+  trigger_paths : [ OnSpillSignalPath ]
+  outpath: [ OnSpillOutput]
   end_paths: [outpath]
 }
 outputs: {
@@ -49,7 +35,7 @@ outputs: {
     module_type: RootOutput
     fileName : "dts.owner.CosmicOnSpill.version.sequencer.art"
     outputCommands:   [ "keep *_*_*_*" ]
-    SelectEvents: [OnSpillSignalPath, OnSpillCalibPath]
+    SelectEvents: [OnSpillSignalPath]
   }
 }
 #include "Production/JobConfig/common/epilog.fcl"

--- a/JobConfig/cosmic/SpillSplitter.fcl
+++ b/JobConfig/cosmic/SpillSplitter.fcl
@@ -18,18 +18,18 @@ physics: {
       MinimumPartMom : 50
       MaximumPartMom : 250
       MinimumTrkSteps : 15
-      MinimumTrkPlanes : 7
+      MinimumTrkPlanes : 0
       MinimumTrkPlaneSpan : 16
-      MaxImpact : 100.0
+      MaxImpact : 150.0
     }
     CalibFilter : { # select events interesting for calibration: reflecting cosmics, etc
       module_type : CosmicMixingFilter
       StrawGasSteps : "compressDetStepMCs"
       MinimumPartMom : 50
       MaximumPartMom : 300
-      MinimumTrkSteps : 60
-      MinimumTrkPlanes : 30
-      MinimumTrkPlaneSpan : 30
+      MinimumTrkSteps : 100
+      MinimumTrkPlanes : 32
+      MinimumTrkPlaneSpan : 32
       MaxImpact : 1000.0 # no cut on impact
     }
   }

--- a/JobConfig/cosmic/SpillSplitter.fcl
+++ b/JobConfig/cosmic/SpillSplitter.fcl
@@ -1,6 +1,5 @@
 #
-# select cosmic primarys for digitization.  OnSpill (mixing) requires a signal
-# or calibration-like track, # Offspill is simply prescaled
+# select cosmic primarys for digitization.   (mixing) requires a signal
 #
 #include "Offline/fcl/standardServices.fcl"
 #include "Production/JobConfig/common/prolog.fcl"
@@ -11,31 +10,47 @@ services : @local::Services.Sim
 services.SeedService.baseSeed : @local::Common.BaseSeed
 physics: {
   filters : {
-    OnSpillSignalFilter : { # select particles in the Ce signal momentum band, with no cut on the hits
+    SignalFilter : { # select particles in the Ce signal momentum band, with no cut on the hits
       # this selection is 100% efficient for Ces, and accepts 98% of cosmics
-      # which pass an OnSpill triggers
+      # which pass an  triggers
       module_type : CosmicMixingFilter
       StrawGasSteps : "compressDetStepMCs"
       MinimumPartMom : 50
       MaximumPartMom : 250
       MinimumTrkSteps : 15
       MinimumTrkPlanes : 7
-      MinimumTrkPlaneSpan : 18
-      MaxImpact : 250.0
+      MinimumTrkPlaneSpan : 16
+      MaxImpact : 100.0
+    }
+    CalibFilter : { # select events interesting for calibration: reflecting cosmics, etc
+      module_type : CosmicMixingFilter
+      StrawGasSteps : "compressDetStepMCs"
+      MinimumPartMom : 50
+      MaximumPartMom : 300
+      MinimumTrkSteps : 60
+      MinimumTrkPlanes : 30
+      MinimumTrkPlaneSpan : 30
+      MaxImpact : 1000.0 # no cut on impact
     }
   }
-  # Eventually add calibration paths and OffSpill paths TODO
-  OnSpillSignalPath : [OnSpillSignalFilter ]
-  trigger_paths : [ OnSpillSignalPath ]
-  outpath: [ OnSpillOutput]
+  SignalPath : [SignalFilter ]
+  CalibPath : [CalibFilter ]
+  trigger_paths : [ CalibPath,  SignalPath ]
+  outpath: [ SignalOutput]
   end_paths: [outpath]
 }
 outputs: {
-  OnSpillOutput: {
+  SignalOutput: {
     module_type: RootOutput
-    fileName : "dts.owner.CosmicOnSpill.version.sequencer.art"
+    fileName : "dts.owner.CosmicSignal.version.sequencer.art"
     outputCommands:   [ "keep *_*_*_*" ]
-    SelectEvents: [OnSpillSignalPath]
+    SelectEvents: [SignalPath]
+  }
+  CalibOutput: {
+    module_type: RootOutput
+    fileName : "dts.owner.CosmicCalib.version.sequencer.art"
+    outputCommands:   [ "keep *_*_*_*" ]
+    SelectEvents: [CalibPath]
   }
 }
 #include "Production/JobConfig/common/epilog.fcl"

--- a/JobConfig/cosmic/SpillSplitter.fcl
+++ b/JobConfig/cosmic/SpillSplitter.fcl
@@ -3,6 +3,7 @@
 # requires there be a signal-like particle, Offspill is simply prescaled
 #
 #include "Offline/fcl/standardServices.fcl"
+#include "Production/JobConfig/common/prolog.fcl"
 #include "Production/JobConfig/primary/prolog.fcl"
 process_name: cosmicsplitter
 source: { module_type: RootInput }
@@ -11,29 +12,36 @@ services.SeedService.baseSeed : @local::Common.BaseSeed
 physics: {
   filters : {
     OnSpillSignalFilter : { # select particles in the Ce signal momentum band, with no cut on the hits
-      @table::Primary.filters.PrimaryFilter
+      module_type : DetectorStepFilter
+      CaloShowerSteps : [ ]  # don't allow calo clusters themselves to pass
+      CrvSteps : [ ] # dont filter on CRV since that can't trigger
+      StrawGasSteps : [ "compressDetStepMCs" ]
+      KeepPDG : [ ] # Loop at steps from all particle types
+      #      KeepPDG : [ 11,-11, 13, -13] # e+-, mu+-
       MinimumPartMom : 80
       MaximumPartMom : 120
-      CaloShowerSteps : [ ]
-      StrawGasSteps : [ "compressDetStepMCs" ]
+      MinimumTrkSteps : 20
+      #      TimeCutConfig : {
+      #        MinimumTime : 400
+      #        MaximumTime : 1700
+      #      }
     }
     OnSpillCalibFilter : { # select particles with many hits (large multi-loop helices)
-      @table::Primary.filters.PrimaryFilter
-      CaloShowerSteps : [ ]
+      module_type : DetectorStepFilter
+      CaloShowerSteps : [ ]  # don't allow calo clusters themselves to pass
+      CrvSteps : [ ] # dont filter on CRV since that can't trigger
       StrawGasSteps : [ "compressDetStepMCs" ]
+      KeepPDG : [ ] # Loop at steps from all particle types
+      MinimumPartMom : 45
+      MaximumPartMom : 250
       MinimumTrkSteps: 60
-    }
-    OffSpillFilter : {
-      module_type : RandomPrescaleFilter
-      nPrescale : 0 # Not sure if this is necessary.  Maybe this should only apply to straight tracks??
     }
 
   }
   OnSpillSignalPath : [OnSpillSignalFilter ]
   OnSpillCalibPath : [OnSpillCalibFilter ]
-  OffSpillPath : [ OffSpillFilter ]
-  trigger_paths : [ OnSpillSignalPath, OnSpillCalibPath, OffSpillPath ]
-  outpath: [ OnSpillOutput, OffSpillOutput ]
+  trigger_paths : [ OnSpillSignalPath, OnSpillCalibPath ]
+  outpath: [ OnSpillOutput ]
   end_paths: [outpath]
 }
 outputs: {
@@ -42,12 +50,6 @@ outputs: {
     fileName : "dts.owner.CosmicOnSpill.version.sequencer.art"
     outputCommands:   [ "keep *_*_*_*" ]
     SelectEvents: [OnSpillSignalPath, OnSpillCalibPath]
-  }
-  OffSpillOutput: {
-    module_type: RootOutput
-    fileName : "dts.owner.CosmicOffSpill.version.sequencer.art"
-    outputCommands:   [ "keep *_*_*_*" ]
-    SelectEvents: [OffSpillPath]
   }
 }
 #include "Production/JobConfig/common/epilog.fcl"


### PR DESCRIPTION
script to pre-select Cosmic events prior to digitization.  Currently this selects signal-like tracks, but in future it should select OnSpill and OffSpill calibration events too, as separate streams. 