### PR TITLE
Fixing RPC scripts

### DIFF
--- a/JobConfig/primary/RPC.fcl
+++ b/JobConfig/primary/RPC.fcl
@@ -1,5 +1,5 @@
 #
-# RPC photon spectrum, based on on Bistrilich spectrum 
+# RPC photon spectrum, based on on Bistrilich spectrum
 # Option of Internal or External to be set in driving FCL instance
 # original author: S Middleton
 #
@@ -21,6 +21,4 @@ physics.producers.generate : {
   doHistograms : true
 }
 
-physics.producers.FindMCPrimary.PrimaryProcess : @nil 
-
-
+physics.producers.FindMCPrimary.PrimaryProcess : @nil

--- a/JobConfig/primary/RPCExternal.fcl
+++ b/JobConfig/primary/RPCExternal.fcl
@@ -1,0 +1,9 @@
+#
+# RPC External
+#
+
+#include "Production/JobConfig/primary/RPC.fcl"
+
+physics.producers.generate.RPCType : "mu2eExternalRPC"
+physics.producers.FindMCPrimary.PrimaryProcess : "mu2eExternalRPC"
+outputs.PrimaryOutput.fileName: "dts.owner.RPCExternal.version.sequencer.art"

--- a/JobConfig/primary/RPCInternal.fcl
+++ b/JobConfig/primary/RPCInternal.fcl
@@ -1,0 +1,9 @@
+#
+# RPC Internal
+#
+
+#include "Production/JobConfig/primary/RPC.fcl"
+
+physics.producers.generate.RPCType : "mu2eInternalRPC"
+physics.producers.FindMCPrimary.PrimaryProcess : "mu2eInternalRPC"
+outputs.PrimaryOutput.fileName: "dts.owner.RPCInternal.version.sequencer.art"

--- a/Scripts/gen_Primary.sh
+++ b/Scripts/gen_Primary.sh
@@ -7,7 +7,7 @@
 # $2 is the production (ie MDC2020)
 # $3 is the stops production version
 # $4 is the output primary production version
-# $5 is the kind of input stops (Muminus, Muplus, IPAMuminus, IPAMuplus, or Cosmic)
+# $5 is the kind of input stops (Muminus, Muplus, IPAMuminus, IPAMuplus, Piminus, Piplus, or Cosmic)
 # $6 is the number of jobs
 # $7 is the number of events/job
 if [[ $# -lt 7 ]]; then
@@ -21,14 +21,16 @@ stype=$5
 njobs=$6
 eventsperjob=$7
 
+dataset=sim.mu2e.${stype}StopsCat.${stopsconf}.art
+
 if [[ "${stype}" == "Muminus" ]] ||  [[ "${stype}" == "Muplus" ]]; then
-  dataset=sim.mu2e.${stype}StopsCat.${stopsconf}.art
   resampler=TargetStopResampler
+elif [[ "${stype}" == "Piminus" ]] ||  [[ "${stype}" == "Piplus" ]]; then
+  resampler=TargetPiStopResampler
 elif [[ "${stype}" == "Cosmic" ]]; then
   dataset=sim.mu2e.${stype}DSStops${primary}.${stopsconf}.art   # should have Cat FIXME!
   resampler=${stype}Resampler
 else
-  dataset=sim.mu2e.${stype}StopsCat.${stopsconf}.art
   resampler=${stype}StopResampler
 fi
 


### PR DESCRIPTION
We fix the `gen_Primary.sh` script and the RPC fcl files to generate and mix RPC primaries. 