### PR TITLE
add nightly validation fcl

### DIFF
--- a/Validation/nightly/ceMix_00.fcl
+++ b/Validation/nightly/ceMix_00.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 367679958703210497
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/4a/8a/dts.mu2e.CeEndpoint.MDC2020k.001210_00000000.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/58/da/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000009.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/82/98/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000000.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000000.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000000.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_00.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_01.fcl
+++ b/Validation/nightly/ceMix_01.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 185524087235444737
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/2c/49/dts.mu2e.CeEndpoint.MDC2020k.001210_00000001.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/5d/db/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000007.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/8a/fe/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000004.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000001.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000001.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_01.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_02.fcl
+++ b/Validation/nightly/ceMix_02.fcl
@@ -1,0 +1,44 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+# 10/12/21 job taking too long, try changing seed
+#services.SeedService.baseSeed: 559456228882219009
+# new:
+services.SeedService.baseSeed: 559456229992219009
+#
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/8d/cc/dts.mu2e.CeEndpoint.MDC2020k.001210_00000002.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/76/7b/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000004.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+
+# this file may be contrbuting to slow execution, swapped with ceMix_49.fcl 10/13/21
+#"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/89/94/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000003.art"
+
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/d6/71/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000009.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000002.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000002.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_02.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_03.fcl
+++ b/Validation/nightly/ceMix_03.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 4103954481563959297
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/71/bb/dts.mu2e.CeEndpoint.MDC2020k.001210_00000003.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/81/87/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000002.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/99/60/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000008.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000003.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000003.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_03.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_04.fcl
+++ b/Validation/nightly/ceMix_04.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 2838919842116403201
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/3f/de/dts.mu2e.CeEndpoint.MDC2020k.001210_00000004.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/a0/fc/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/9c/93/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000005.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000004.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000004.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_04.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_05.fcl
+++ b/Validation/nightly/ceMix_05.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 1723798939691417601
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/5e/c7/dts.mu2e.CeEndpoint.MDC2020k.001210_00000005.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/23/5e/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000005.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/9e/4c/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000007.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000005.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000005.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_05.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_06.fcl
+++ b/Validation/nightly/ceMix_06.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 2777206041690275841
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/97/f8/dts.mu2e.CeEndpoint.MDC2020k.001210_00000006.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/30/3a/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000001.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/3c/5e/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000002.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000006.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000006.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_06.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_07.fcl
+++ b/Validation/nightly/ceMix_07.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 2619233507082371073
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/b6/be/dts.mu2e.CeEndpoint.MDC2020k.001210_00000007.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/30/3a/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000001.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/d6/71/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000009.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000007.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000007.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_07.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_08.fcl
+++ b/Validation/nightly/ceMix_08.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 4128314123963269121
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/40/c8/dts.mu2e.CeEndpoint.MDC2020k.001210_00000008.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/7a/31/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000003.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/06/62/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000006.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000008.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000008.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_08.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_09.fcl
+++ b/Validation/nightly/ceMix_09.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 3608599011493511169
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/76/d9/dts.mu2e.CeEndpoint.MDC2020k.001210_00000009.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/b1/ef/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000006.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/d6/71/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000009.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000009.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000009.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_09.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_10.fcl
+++ b/Validation/nightly/ceMix_10.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 367679958703210410
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/4a/8a/dts.mu2e.CeEndpoint.MDC2020k.001210_00000000.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/58/da/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000009.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/82/98/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000000.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000000.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000000.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_10.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_11.fcl
+++ b/Validation/nightly/ceMix_11.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 185524087235444711
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/2c/49/dts.mu2e.CeEndpoint.MDC2020k.001210_00000001.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/5d/db/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000007.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/8a/fe/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000004.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000001.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000001.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_11.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_12.fcl
+++ b/Validation/nightly/ceMix_12.fcl
@@ -1,0 +1,44 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+# 10/12/21 job taking too long, try changing seed
+#services.SeedService.baseSeed: 559456228882219009
+# new:
+services.SeedService.baseSeed: 559456229992219012
+#
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/8d/cc/dts.mu2e.CeEndpoint.MDC2020k.001210_00000002.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/76/7b/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000004.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+
+# this file may be contrbuting to slow execution, swapped with ceMix_49.fcl 10/13/21
+#"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/89/94/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000003.art"
+
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/d6/71/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000009.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000002.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000002.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_12.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_13.fcl
+++ b/Validation/nightly/ceMix_13.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 4103954481563959213
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/71/bb/dts.mu2e.CeEndpoint.MDC2020k.001210_00000003.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/81/87/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000002.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/99/60/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000008.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000003.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000003.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_13.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_14.fcl
+++ b/Validation/nightly/ceMix_14.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 2838919842116403214
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/3f/de/dts.mu2e.CeEndpoint.MDC2020k.001210_00000004.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/a0/fc/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/9c/93/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000005.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000004.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000004.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_14.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_15.fcl
+++ b/Validation/nightly/ceMix_15.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 1723798939691417615
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/5e/c7/dts.mu2e.CeEndpoint.MDC2020k.001210_00000005.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/23/5e/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000005.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/9e/4c/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000007.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000005.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000005.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_15.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_16.fcl
+++ b/Validation/nightly/ceMix_16.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 2777206041690275816
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/97/f8/dts.mu2e.CeEndpoint.MDC2020k.001210_00000006.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/30/3a/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000001.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/3c/5e/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000002.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000006.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000006.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_16.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_17.fcl
+++ b/Validation/nightly/ceMix_17.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 2619233507082371017
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/b6/be/dts.mu2e.CeEndpoint.MDC2020k.001210_00000007.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/30/3a/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000001.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/d6/71/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000009.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000007.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000007.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_17.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_18.fcl
+++ b/Validation/nightly/ceMix_18.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 4128314123963269118
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/40/c8/dts.mu2e.CeEndpoint.MDC2020k.001210_00000008.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/7a/31/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000003.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/06/62/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000006.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000008.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000008.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_18.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_19.fcl
+++ b/Validation/nightly/ceMix_19.fcl
@@ -1,0 +1,36 @@
+#include "Production/JobConfig/mixing/Mix.fcl"
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 217395
+physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25596
+physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 90630
+physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 429692
+outputs.SignalOutput.fileName: "dig.owner.CeEndpointMixTriggered.version.sequencer.art"
+outputs.UntriggeredOutput.fileName: "dig.owner.CeEndpointMixUntriggered.version.sequencer.art"
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+services.SeedService.baseSeed: 3608599011493511119
+source.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/CeEndpoint/MDC2020k/art/76/d9/dts.mu2e.CeEndpoint.MDC2020k.001210_00000009.art"
+]
+physics.filters.MuStopPileupMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuStopPileupCat/MDC2020k/art/28/ae/dts.mu2e.MuStopPileupCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.EleBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/EleBeamFlashCat/MDC2020k/art/b1/ef/dts.mu2e.EleBeamFlashCat.MDC2020k.001201_00000006.art"
+]
+physics.filters.MuBeamFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/MuBeamFlashCat/MDC2020k/art/8e/06/dts.mu2e.MuBeamFlashCat.MDC2020k.001201_00000000.art"
+]
+physics.filters.NeutralsFlashMixer.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/dts/mu2e/NeutralsFlashCat/MDC2020k/art/d6/71/dts.mu2e.NeutralsFlashCat.MDC2020k.001201_00000009.art"
+]
+outputs.TriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixTriggered.MU2EGRIDDSCONF.001210_00000009.art"
+outputs.UntriggeredOutput.fileName : "dig.MU2EGRIDDSOWNER.CeEndpointMixUntriggered.MU2EGRIDDSCONF.001210_00000009.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "source.fileNames", "physics.filters.MuStopPileupMixer.fileNames", "physics.filters.EleBeamFlashMixer.fileNames", "physics.filters.MuBeamFlashMixer.fileNames", "physics.filters.NeutralsFlashMixer.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.TriggeredOutput.fileName", "outputs.UntriggeredOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+outputs.SignalOutput.fileName: "ceMix_19.art"
+#include "Production/Validation/nightly/ceMix_common.fcl"

--- a/Validation/nightly/ceMix_common.fcl
+++ b/Validation/nightly/ceMix_common.fcl
@@ -1,0 +1,40 @@
+outputs.UntriggeredOutput.fileName: "/dev/null"
+services.TFileService.fileName: "/dev/null"
+outputs.CaloOutput.fileName: "/dev/null"
+outputs.DiagOutput.fileName: "/dev/null"
+outputs.TrkOutput.fileName: "/dev/null"
+
+services.scheduler.wantSummary: true
+
+services.DbService.purpose: MDC2020_best
+services.DbService.version: v1_0
+services.DbService.verbose: 2
+
+
+source.maxEvents: 500
+
+# remove SimParticle and StepPointMC and MCTrajectory
+outputs.TriggeredOutput.outputCommands: [ 
+   "drop *_*_*_*",
+   "keep mu2e::StrawDigis_*_*_*",
+   "keep mu2e::StrawDigiADCWaveforms_*_*_*",
+   "keep mu2e::CaloDigis_*_*_*",
+   "keep mu2e::CrvDigis_*_*_*",
+   "keep mu2e::StatusG4_*_*_*",
+   "keep *_genCounter_*_*",
+   "keep mu2e::EventWindowMarker_*_*_*",
+   "keep mu2e::ProtonBunchTimeMC_*_*_*",
+   "keep mu2e::ProtonBunchTime_*_*_*",
+   "keep mu2e::EventWeight_*_*_*",
+   "keep *_compressDigiMCs_*_*",
+   "keep mu2e::TriggerInfo_*_*_*",
+   "keep art::TriggerResults_*_*_*",
+   "keep mu2e::KalSeeds_TT*_*_*",
+   "keep mu2e::HelixSeeds_TT*_*_*",
+   "keep mu2e::TimeClusters_TT*_*_*",
+   "keep mu2e::CaloClusters_CaloClusterFast_*_*",
+   "keep mu2e::ProtonBunchIntensity*_*_*_*",
+   "drop mu2e::StepPointMCs_*_*_*",
+   "drop mu2e::SimParticlemv_*_*_*", 
+   "drop *MCTrajectory*_*_*_*" 
+]

--- a/Validation/nightly/pileup_00.fcl
+++ b/Validation/nightly/pileup_00.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/EleBeamResampler.fcl"
+physics.filters.beamResampler.mu2e.MaxEventsToSkip: 328981
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 0
+source.maxEvents: 400000
+services.SeedService.baseSeed: 6411963896717934593
+physics.filters.beamResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/scratch/datasets/phy-sim/sim/mu2e/EleBeamCat/MDC2020k/art/23/96/sim.mu2e.EleBeamCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyEleBeamFlash.MU2EGRIDDSCONF.001202_00000000.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EleBeamFlash.MU2EGRIDDSCONF.001202_00000000.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.beamResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_00.art"

--- a/Validation/nightly/pileup_01.fcl
+++ b/Validation/nightly/pileup_01.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/EleBeamResampler.fcl"
+physics.filters.beamResampler.mu2e.MaxEventsToSkip: 328981
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 1
+source.maxEvents: 400000
+services.SeedService.baseSeed: 477464047849144321
+physics.filters.beamResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/scratch/datasets/phy-sim/sim/mu2e/EleBeamCat/MDC2020k/art/23/96/sim.mu2e.EleBeamCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyEleBeamFlash.MU2EGRIDDSCONF.001202_00000001.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EleBeamFlash.MU2EGRIDDSCONF.001202_00000001.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.beamResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_01.art"

--- a/Validation/nightly/pileup_02.fcl
+++ b/Validation/nightly/pileup_02.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/EleBeamResampler.fcl"
+physics.filters.beamResampler.mu2e.MaxEventsToSkip: 328981
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 2
+source.maxEvents: 400000
+services.SeedService.baseSeed: 8387245961827221505
+physics.filters.beamResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/scratch/datasets/phy-sim/sim/mu2e/EleBeamCat/MDC2020k/art/23/96/sim.mu2e.EleBeamCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyEleBeamFlash.MU2EGRIDDSCONF.001202_00000002.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EleBeamFlash.MU2EGRIDDSCONF.001202_00000002.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.beamResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_02.art"

--- a/Validation/nightly/pileup_03.fcl
+++ b/Validation/nightly/pileup_03.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/EleBeamResampler.fcl"
+physics.filters.beamResampler.mu2e.MaxEventsToSkip: 328981
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 3
+source.maxEvents: 400000
+services.SeedService.baseSeed: 4785506801458839553
+physics.filters.beamResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/scratch/datasets/phy-sim/sim/mu2e/EleBeamCat/MDC2020k/art/23/96/sim.mu2e.EleBeamCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyEleBeamFlash.MU2EGRIDDSCONF.001202_00000003.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EleBeamFlash.MU2EGRIDDSCONF.001202_00000003.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.beamResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_03.art"

--- a/Validation/nightly/pileup_04.fcl
+++ b/Validation/nightly/pileup_04.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/EleBeamResampler.fcl"
+physics.filters.beamResampler.mu2e.MaxEventsToSkip: 328981
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 4
+source.maxEvents: 400000
+services.SeedService.baseSeed: 1106506574642577409
+physics.filters.beamResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/scratch/datasets/phy-sim/sim/mu2e/EleBeamCat/MDC2020k/art/23/96/sim.mu2e.EleBeamCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyEleBeamFlash.MU2EGRIDDSCONF.001202_00000004.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EleBeamFlash.MU2EGRIDDSCONF.001202_00000004.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.beamResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_04.art"

--- a/Validation/nightly/pileup_05.fcl
+++ b/Validation/nightly/pileup_05.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/EleBeamResampler.fcl"
+physics.filters.beamResampler.mu2e.MaxEventsToSkip: 328981
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 5
+source.maxEvents: 400000
+services.SeedService.baseSeed: 7165138646933536769
+physics.filters.beamResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/scratch/datasets/phy-sim/sim/mu2e/EleBeamCat/MDC2020k/art/23/96/sim.mu2e.EleBeamCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyEleBeamFlash.MU2EGRIDDSCONF.001202_00000005.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EleBeamFlash.MU2EGRIDDSCONF.001202_00000005.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.beamResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_05.art"

--- a/Validation/nightly/pileup_06.fcl
+++ b/Validation/nightly/pileup_06.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/EleBeamResampler.fcl"
+physics.filters.beamResampler.mu2e.MaxEventsToSkip: 328981
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 6
+source.maxEvents: 400000
+services.SeedService.baseSeed: 7377008745970040833
+physics.filters.beamResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/scratch/datasets/phy-sim/sim/mu2e/EleBeamCat/MDC2020k/art/23/96/sim.mu2e.EleBeamCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyEleBeamFlash.MU2EGRIDDSCONF.001202_00000006.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EleBeamFlash.MU2EGRIDDSCONF.001202_00000006.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.beamResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_06.art"

--- a/Validation/nightly/pileup_07.fcl
+++ b/Validation/nightly/pileup_07.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/EleBeamResampler.fcl"
+physics.filters.beamResampler.mu2e.MaxEventsToSkip: 328981
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 7
+source.maxEvents: 400000
+services.SeedService.baseSeed: 1876059260509454337
+physics.filters.beamResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/scratch/datasets/phy-sim/sim/mu2e/EleBeamCat/MDC2020k/art/23/96/sim.mu2e.EleBeamCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyEleBeamFlash.MU2EGRIDDSCONF.001202_00000007.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EleBeamFlash.MU2EGRIDDSCONF.001202_00000007.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.beamResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_07.art"

--- a/Validation/nightly/pileup_08.fcl
+++ b/Validation/nightly/pileup_08.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/EleBeamResampler.fcl"
+physics.filters.beamResampler.mu2e.MaxEventsToSkip: 328981
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 8
+source.maxEvents: 400000
+services.SeedService.baseSeed: 1120060430390689793
+physics.filters.beamResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/scratch/datasets/phy-sim/sim/mu2e/EleBeamCat/MDC2020k/art/23/96/sim.mu2e.EleBeamCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyEleBeamFlash.MU2EGRIDDSCONF.001202_00000008.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EleBeamFlash.MU2EGRIDDSCONF.001202_00000008.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.beamResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_08.art"

--- a/Validation/nightly/pileup_09.fcl
+++ b/Validation/nightly/pileup_09.fcl
@@ -1,0 +1,26 @@
+#include "Production/JobConfig/pileup/MuBeamResampler.fcl"
+physics.filters.beamResampler.mu2e.MaxEventsToSkip: 8934
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 4
+source.maxEvents: 400000
+services.SeedService.baseSeed: 2988434984596176897
+physics.filters.beamResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/scratch/datasets/phy-sim/sim/mu2e/MuBeamCat/MDC2020k/art/87/c4/sim.mu2e.MuBeamCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyMuBeamFlash.MU2EGRIDDSCONF.001202_00000004.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.MuBeamFlash.MU2EGRIDDSCONF.001202_00000004.art"
+outputs.IPAStopOutput.fileName : "sim.MU2EGRIDDSOWNER.IPAStops.MU2EGRIDDSCONF.001202_00000004.art"
+outputs.TargetStopOutput.fileName : "sim.MU2EGRIDDSOWNER.TargetStops.MU2EGRIDDSCONF.001202_00000004.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.beamResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName", "outputs.IPAStopOutput.fileName", "outputs.TargetStopOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+outputs.valCombo.SelectEvents: [ "earlyFlashPath", "targetStopPath" ]
+physics.filters.TargetStopPrescaleFilter.nPrescale : 1
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_09.art"

--- a/Validation/nightly/pileup_10.fcl
+++ b/Validation/nightly/pileup_10.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/NeutralsResampler.fcl"
+physics.filters.neutralsResampler.mu2e.MaxEventsToSkip: 1331172
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 0
+source.maxEvents: 400000
+services.SeedService.baseSeed: 8989169057873821697
+physics.filters.neutralsResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/sim/mu2e/NeutralsCat/MDC2020k/art/1c/b8/sim.mu2e.NeutralsCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyNeutralsFlash.MU2EGRIDDSCONF.001202_00000000.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.NeutralsFlash.MU2EGRIDDSCONF.001202_00000000.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.neutralsResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_10.art"

--- a/Validation/nightly/pileup_11.fcl
+++ b/Validation/nightly/pileup_11.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/NeutralsResampler.fcl"
+physics.filters.neutralsResampler.mu2e.MaxEventsToSkip: 1331172
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 1
+source.maxEvents: 400000
+services.SeedService.baseSeed: 6842164283368898561
+physics.filters.neutralsResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/sim/mu2e/NeutralsCat/MDC2020k/art/1c/b8/sim.mu2e.NeutralsCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyNeutralsFlash.MU2EGRIDDSCONF.001202_00000001.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.NeutralsFlash.MU2EGRIDDSCONF.001202_00000001.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.neutralsResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_11.art"

--- a/Validation/nightly/pileup_12.fcl
+++ b/Validation/nightly/pileup_12.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/NeutralsResampler.fcl"
+physics.filters.neutralsResampler.mu2e.MaxEventsToSkip: 1331172
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 2
+source.maxEvents: 400000
+services.SeedService.baseSeed: 1015690067958202369
+physics.filters.neutralsResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/sim/mu2e/NeutralsCat/MDC2020k/art/1c/b8/sim.mu2e.NeutralsCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyNeutralsFlash.MU2EGRIDDSCONF.001202_00000002.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.NeutralsFlash.MU2EGRIDDSCONF.001202_00000002.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.neutralsResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_12.art"

--- a/Validation/nightly/pileup_13.fcl
+++ b/Validation/nightly/pileup_13.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/NeutralsResampler.fcl"
+physics.filters.neutralsResampler.mu2e.MaxEventsToSkip: 1331172
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 3
+source.maxEvents: 400000
+services.SeedService.baseSeed: 7042323602949767169
+physics.filters.neutralsResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/sim/mu2e/NeutralsCat/MDC2020k/art/1c/b8/sim.mu2e.NeutralsCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyNeutralsFlash.MU2EGRIDDSCONF.001202_00000003.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.NeutralsFlash.MU2EGRIDDSCONF.001202_00000003.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.neutralsResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_13.art"

--- a/Validation/nightly/pileup_14.fcl
+++ b/Validation/nightly/pileup_14.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/NeutralsResampler.fcl"
+physics.filters.neutralsResampler.mu2e.MaxEventsToSkip: 1331172
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 4
+source.maxEvents: 400000
+services.SeedService.baseSeed: 8995898330268860417
+physics.filters.neutralsResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/sim/mu2e/NeutralsCat/MDC2020k/art/1c/b8/sim.mu2e.NeutralsCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyNeutralsFlash.MU2EGRIDDSCONF.001202_00000004.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.NeutralsFlash.MU2EGRIDDSCONF.001202_00000004.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.neutralsResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_14.art"

--- a/Validation/nightly/pileup_15.fcl
+++ b/Validation/nightly/pileup_15.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/NeutralsResampler.fcl"
+physics.filters.neutralsResampler.mu2e.MaxEventsToSkip: 1331172
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 5
+source.maxEvents: 400000
+services.SeedService.baseSeed: 381245587529760769
+physics.filters.neutralsResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/sim/mu2e/NeutralsCat/MDC2020k/art/1c/b8/sim.mu2e.NeutralsCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyNeutralsFlash.MU2EGRIDDSCONF.001202_00000005.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.NeutralsFlash.MU2EGRIDDSCONF.001202_00000005.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.neutralsResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_15.art"

--- a/Validation/nightly/pileup_16.fcl
+++ b/Validation/nightly/pileup_16.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/NeutralsResampler.fcl"
+physics.filters.neutralsResampler.mu2e.MaxEventsToSkip: 1331172
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 6
+source.maxEvents: 400000
+services.SeedService.baseSeed: 3638721474841182209
+physics.filters.neutralsResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/sim/mu2e/NeutralsCat/MDC2020k/art/1c/b8/sim.mu2e.NeutralsCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyNeutralsFlash.MU2EGRIDDSCONF.001202_00000006.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.NeutralsFlash.MU2EGRIDDSCONF.001202_00000006.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.neutralsResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_16.art"

--- a/Validation/nightly/pileup_17.fcl
+++ b/Validation/nightly/pileup_17.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/NeutralsResampler.fcl"
+physics.filters.neutralsResampler.mu2e.MaxEventsToSkip: 1331172
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 7
+source.maxEvents: 400000
+services.SeedService.baseSeed: 6144227045061656577
+physics.filters.neutralsResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/sim/mu2e/NeutralsCat/MDC2020k/art/1c/b8/sim.mu2e.NeutralsCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyNeutralsFlash.MU2EGRIDDSCONF.001202_00000007.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.NeutralsFlash.MU2EGRIDDSCONF.001202_00000007.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.neutralsResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_17.art"

--- a/Validation/nightly/pileup_18.fcl
+++ b/Validation/nightly/pileup_18.fcl
@@ -1,0 +1,22 @@
+#include "Production/JobConfig/pileup/NeutralsResampler.fcl"
+physics.filters.neutralsResampler.mu2e.MaxEventsToSkip: 1331172
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 8
+source.maxEvents: 400000
+services.SeedService.baseSeed: 3995485168275587073
+physics.filters.neutralsResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/sim/mu2e/NeutralsCat/MDC2020k/art/1c/b8/sim.mu2e.NeutralsCat.MDC2020k.001201_00000000.art"
+]
+outputs.EarlyFlashOutput.fileName : "dts.MU2EGRIDDSOWNER.EarlyNeutralsFlash.MU2EGRIDDSCONF.001202_00000008.art"
+outputs.FlashOutput.fileName : "dts.MU2EGRIDDSOWNER.NeutralsFlash.MU2EGRIDDSCONF.001202_00000008.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.neutralsResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.EarlyFlashOutput.fileName", "outputs.FlashOutput.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+physics.filters.EarlyPrescaleFilter.nPrescale : 1
+outputs.valCombo.fileName: "pileup_18.art"

--- a/Validation/nightly/pileup_19.fcl
+++ b/Validation/nightly/pileup_19.fcl
@@ -1,0 +1,23 @@
+#include "Production/JobConfig/pileup/MuStopPileup.fcl"
+physics.filters.TargetStopResampler.mu2e.MaxEventsToSkip: 14094
+
+#----------------------------------------------------------------
+# Code added by generate_fcl:
+source.firstRun: 1202
+source.firstSubRun: 4
+source.maxEvents: 400000
+services.SeedService.baseSeed: 8481692510445666305
+physics.filters.TargetStopResampler.fileNames : [
+"root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/tape/phy-sim/sim/mu2e/TargetStopsCat/MDC2020k/art/63/9d/sim.mu2e.TargetStopsCat.MDC2020k.001201_00000000.art"
+]
+outputs.Output.fileName : "dts.MU2EGRIDDSOWNER.MuStopPileup.MU2EGRIDDSCONF.001202_00000004.art"
+mu2emetadata.fcl.prologkeys: [  ]
+mu2emetadata.fcl.inkeys: [ "physics.filters.TargetStopResampler.fileNames" ]
+mu2emetadata.fcl.outkeys: [ "outputs.Output.fileName" ]
+# End code added by generate_fcl:
+#----------------------------------------------------------------
+#include "Production/Validation/nightly/pileup_common.fcl"
+
+outputs.valCombo.SelectEvents: [ "PileupPath"]
+physics.producers.compressDetStepMCs.compressionOptions.keepNGenerations : 0
+outputs.valCombo.fileName: "pileup_19.art"

--- a/Validation/nightly/pileup_common.fcl
+++ b/Validation/nightly/pileup_common.fcl
@@ -1,0 +1,36 @@
+#
+# commands in common with the 4 different kinds of pile-up jobs
+#
+services.scheduler.num_schedules: 1
+services.scheduler.num_threads: 1
+
+outputs: {
+   valCombo: {
+      SelectEvents: [ "earlyFlashPath" ]
+      fileName: "pileup.art"
+      module_type: "RootOutput"
+      outputCommands: [
+         "drop *_*_*_*",
+         "keep art::EventIDs_*_*_*",
+         "keep mu2e::GenEventCount_*_*_*",
+         "keep mu2e::StatusG4_*_*_*",
+         "keep mu2e::SimParticleart::Ptrdoublestd::map_*_*_*",
+         "keep mu2e::StrawGasSteps_compressDetStepMCs_*_*",
+         "keep mu2e::CaloShowerSteps_compressDetStepMCs_*_*",
+         "keep mu2e::CrvSteps_compressDetStepMCs_*_*",
+         "keep mu2e::SimParticlemv_compressDetStepMCs_*_*",
+         "keep mu2e::GenParticles_compressDetStepMCs_*_*",
+	 "keep mu2e::SimParticlemv_TargetStopFilter_*_*"
+      ]
+   }
+}
+
+
+physics.allPath : [ "valCombo" ]
+physics.end_paths : [ "allPath" ]
+
+process_name: pileup
+
+services.scheduler.wantSummary: true
+
+source.maxEvents: 150000

--- a/Validation/nightly/reco_00.fcl
+++ b/Validation/nightly/reco_00.fcl
@@ -1,0 +1,3 @@
+#include "Production/Validation/reco.fcl"
+source.fileNames : ["root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/persistent/users/mu2epro/valjob/reco_031021/dig.brownd.CeEndpointMixTriggered.MDC2020k.001210_00000000.art" ]
+outputs.Output.fileName: "reco_00.art"

--- a/Validation/nightly/reco_01.fcl
+++ b/Validation/nightly/reco_01.fcl
@@ -1,0 +1,3 @@
+#include "Production/Validation/reco.fcl"
+source.fileNames : ["root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/persistent/users/mu2epro/valjob/reco_031021/dig.brownd.CeEndpointMixTriggered.MDC2020k.001210_00000001.art" ]
+outputs.Output.fileName: "reco_01.art"

--- a/Validation/nightly/reco_02.fcl
+++ b/Validation/nightly/reco_02.fcl
@@ -1,0 +1,3 @@
+#include "Production/Validation/reco.fcl"
+source.fileNames : ["root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/persistent/users/mu2epro/valjob/reco_031021/dig.brownd.CeEndpointMixTriggered.MDC2020k.001210_00000002.art" ]
+outputs.Output.fileName: "reco_02.art"

--- a/Validation/nightly/reco_03.fcl
+++ b/Validation/nightly/reco_03.fcl
@@ -1,0 +1,3 @@
+#include "Production/Validation/reco.fcl"
+source.fileNames : ["root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/persistent/users/mu2epro/valjob/reco_031021/dig.brownd.CeEndpointMixTriggered.MDC2020k.001210_00000003.art" ]
+outputs.Output.fileName: "reco_03.art"

--- a/Validation/nightly/reco_04.fcl
+++ b/Validation/nightly/reco_04.fcl
@@ -1,0 +1,3 @@
+#include "Production/Validation/reco.fcl"
+source.fileNames : ["root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/persistent/users/mu2epro/valjob/reco_031021/dig.brownd.CeEndpointMixTriggered.MDC2020k.001210_00000004.art" ]
+outputs.Output.fileName: "reco_04.art"

--- a/Validation/nightly/reco_05.fcl
+++ b/Validation/nightly/reco_05.fcl
@@ -1,0 +1,3 @@
+#include "Production/Validation/reco.fcl"
+source.fileNames : ["root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/persistent/users/mu2epro/valjob/reco_031021/dig.brownd.CeEndpointMixTriggered.MDC2020k.001210_00000005.art" ]
+outputs.Output.fileName: "reco_05.art"

--- a/Validation/nightly/reco_06.fcl
+++ b/Validation/nightly/reco_06.fcl
@@ -1,0 +1,3 @@
+#include "Production/Validation/reco.fcl"
+source.fileNames : ["root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/persistent/users/mu2epro/valjob/reco_031021/dig.brownd.CeEndpointMixTriggered.MDC2020k.001210_00000006.art" ]
+outputs.Output.fileName: "reco_06.art"

--- a/Validation/nightly/reco_07.fcl
+++ b/Validation/nightly/reco_07.fcl
@@ -1,0 +1,3 @@
+#include "Production/Validation/reco.fcl"
+source.fileNames : ["root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/persistent/users/mu2epro/valjob/reco_031021/dig.brownd.CeEndpointMixTriggered.MDC2020k.001210_00000007.art" ]
+outputs.Output.fileName: "reco_07.art"

--- a/Validation/nightly/reco_08.fcl
+++ b/Validation/nightly/reco_08.fcl
@@ -1,0 +1,3 @@
+#include "Production/Validation/reco.fcl"
+source.fileNames : ["root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/persistent/users/mu2epro/valjob/reco_031021/dig.brownd.CeEndpointMixTriggered.MDC2020k.001210_00000008.art" ]
+outputs.Output.fileName: "reco_08.art"

--- a/Validation/nightly/reco_09.fcl
+++ b/Validation/nightly/reco_09.fcl
@@ -1,0 +1,3 @@
+#include "Production/Validation/reco.fcl"
+source.fileNames : ["root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr/mu2e/persistent/users/mu2epro/valjob/reco_031021/dig.brownd.CeEndpointMixTriggered.MDC2020k.001210_00000009.art" ]
+outputs.Output.fileName: "reco_09.art"


### PR DESCRIPTION
This commit adds the fcl that we are running in the nightly validation jobs.  It was being kept with the nightly scripts or being partially generated in the jobs.  Putting it here satisfies a long-standing request from Dave.  Once this is merged, I'll adjust the scripts to use it, then Dave can start upgrading this fcl to more modern input files.  When adjusting this fcl, we want to keep the jobs under 1h on the central machines and keep one output file per job.  Also note that pileup is a combination of 4 variations (0-8,9,10-18,19) and it looks like ceMix is a set of jobs 0-9, duplicated to 10-19 with different seeds.  I don't recall the details, but could probably look up the emails.  