### PR TITLE
Turn off Crv and Calo noise generation in Offspill digitization

### DIFF
--- a/JobConfig/digitize/offspill_epilog.fcl
+++ b/JobConfig/digitize/offspill_epilog.fcl
@@ -8,3 +8,8 @@ physics.producers.TTmakeSH.MaximumRadius : 800.0
 
 physics.producers.TTmakePH.MinimumTime : 0.0
 physics.producers.TTmakePH.MaximumTime : 100.0e3
+# Temporarily turn off Crv noise
+physics.producers.CrvSiPMCharges.ThermalRate : 0
+# same for calorimeter
+physics.producers.CaloDigiMaker.addNoise : false
+physics.producers.CaloDigiMaker.generateSpotNoise : false


### PR DESCRIPTION
This is a temporary fix to address a critical problem digitizing offspill cosmics.  It has minimum impact on the physics simulation of cosmic tracks.  This patch should be replaced with code limiting the noise generation to a narrow window around the cosmic track.