### PR TITLE
Fixes

### DIFF
--- a/JobConfig/primary/IPAMuminusFlateMinus.fcl
+++ b/JobConfig/primary/IPAMuminusFlateMinus.fcl
@@ -6,14 +6,14 @@
 #
 #include "Production/JobConfig/primary/IPAStopParticle.fcl"
 
-physics.filters.DetStepFilter.MinimumPartMom : 10.0 // MeV/c TODO - tweak this parameter to get more DetSteps
+physics.filters.PrimaryFilter.MinimumPartMom : 30.0 // MeV/c TODO - tweak this parameter to get more DetSteps
 physics.producers.FindMCPrimary.PrimaryProcess : "mu2eFlateMinus"
 
 physics.producers.generate : {
   module_type: FlatMuonDaughterGenerator
   inputSimParticles: IPAMuminusStopResampler
   stoppingTargetMaterial : "IPA"
-  verbosity : 1
+  verbosity : 0
   pdgId : 11
 }
 

--- a/JobConfig/primary/IPAMuminusMichel.fcl
+++ b/JobConfig/primary/IPAMuminusMichel.fcl
@@ -6,12 +6,12 @@
 #
 #include "Production/JobConfig/primary/IPAStopParticle.fcl"
 
-physics.filters.DetStepFilter.MinimumPartMom : 10.0 // MeV/c TODO - tweak this parameter to get more DetSteps
+physics.filters.PrimaryFilter.MinimumPartMom : 30.0 // MeV/c TODO - tweak this parameter to get more DetSteps
 physics.producers.FindMCPrimary.PrimaryProcess : "mu2eMuonDecayAtRest"
 
 physics.producers.generate : {
   module_type : Pileup
-  verbosity : 10
+  verbosity : 0
   inputSimParticles: IPAMuminusStopResampler
   captureProducts : []
   decayProducts : [ @local::Pileup.dioGenTool ]


### PR DESCRIPTION
Fix configuration of IPA mustops daughter generators: PrimaryFilter parameters weren't correctly overwritten.  Set the minimum to a reasonable for the current KinKal reco sequence.   Expand and standardize the gen_Primary parameters: note that this will require configuration changes in the POMS files.