### PR TITLE
add database to CI tests

### DIFF
--- a/Validation/ceSteps.fcl
+++ b/Validation/ceSteps.fcl
@@ -13,3 +13,5 @@ physics.filters.TargetStopResampler.fileNames : [
 physics.filters.TargetStopResampler.mu2e.MaxEventsToSkip: 0
 services.GeometryService.inputFile : "Offline/Mu2eG4/geom/geom_common_current.txt"
 outputs.PrimaryOutput.fileName : "dts.owner.ceSteps.dsconf.seq.art"
+
+#include "Production/Validation/database.fcl"

--- a/Validation/muDauSteps.fcl
+++ b/Validation/muDauSteps.fcl
@@ -14,3 +14,4 @@ physics.filters.TargetStopResampler.fileNames : [
 ]
 physics.filters.TargetStopResampler.mu2e.MaxEventsToSkip: 0
 
+#include "Production/Validation/database.fcl"


### PR DESCRIPTION

Dave is turning on database access in more proditions by default.  This means jobs which use these proditions need to have the database configured.  This PR adds the db configuration to more CI test fcl. (already present some places.) The configuration is in `Production/Validation/database.fcl`
which is included many places in validation fcl.