### PR TITLE
follow database turn-on

### DIFF
--- a/Validation/nightly/pileup_epilog.fcl
+++ b/Validation/nightly/pileup_epilog.fcl
@@ -34,3 +34,5 @@ process_name: pileup
 services.scheduler.wantSummary: true
 
 source.maxEvents: 150000
+
+#include "Production/Validation/database.fcl"


### PR DESCRIPTION
should fix nightly pileup jobs