### PR TITLE
use Offline CRV settings for the extracted position

### DIFF
--- a/JobConfig/digitize/Extracted.fcl
+++ b/JobConfig/digitize/Extracted.fcl
@@ -21,18 +21,5 @@ physics.filters.Triggerable.MaxParticleMom : 1e10 # allow 'infintie' momentum co
 # extracted geometry
 services.GeometryService.inputFile: "Offline/Mu2eG4/geom/geom_common_extracted.txt"
 services.GeometryService.bFieldFile: "Offline/Mu2eG4/geom/bfgeom_no_field.txt"
-# setup CRV lookup tables to follow
-physics.producers.CrvPhotons.CRVSectors : ["EX","T1","T2"] # used only to match the vector entries below
-physics.producers.CrvPhotons.reflectors : [  0 ,  1 ,  0 ]
-physics.producers.CrvPhotons.lookupTableFileNames : ["CRVConditions/v6_0/LookupTable_6000_0",  # EX
-  "CRVConditions/v6_0/LookupTable_2370_1",  # T1
-  "CRVConditions/v6_0/LookupTable_3200_0"]  # T2
-# number of photons per MeV visible energy deposited
-# for 68 PE/SiPM @ 1 m away from SiPM (Test beam June 2017)
-# using the pulse height calibration, this value gives 45 PE/SiPM @ 1 m away from SiPM
-physics.producers.CrvPhotons.scintillationYields  : [39400,39400,39400]
-physics.producers.CrvCoincidence.CRVSectors   : ["EX","T1","T2"]
-physics.producers.CrvCoincidence.PEthresholds : [  8 ,  8 ,  8 ]
-physics.producers.CrvCoincidence.adjacentPulseTimeDifferences  : [ 10 , 10 , 10 ]
-physics.producers.CrvCoincidence.maxTimeDifferences            : [ 10 , 10 , 10 ]
-physics.producers.CrvCoincidence.coincidenceLayers             : [  3 ,  3 ,  3 ]
+# override CRV lookup tables, photon yields, etc. for the extracted position
+#include "Offline/CRVResponse/fcl/epilog_extracted.fcl"


### PR DESCRIPTION
This PR removes the overrides done in Production/JobConfig/digitize/Extracted.fcl for the CRV settings in the extracted position, e.g. CRV lookup tables, light yields, etc. It replaces it by including the Offline settings for the extracted position. This is done in the same way as in Production/JobConfig/reco/Extracted.fcl