### PR TITLE
Updated database version to MDC2020_best v1_2

### DIFF
--- a/Validation/database.fcl
+++ b/Validation/database.fcl
@@ -2,5 +2,5 @@
 # Database configuration for validation and CI jobs
 #
 services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_1
+services.DbService.version: v1_2
 services.DbService.verbose : 2

--- a/Validation/nightly/ceMix_00.fcl
+++ b/Validation/nightly/ceMix_00.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_01.fcl
+++ b/Validation/nightly/ceMix_01.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_02.fcl
+++ b/Validation/nightly/ceMix_02.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_03.fcl
+++ b/Validation/nightly/ceMix_03.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_04.fcl
+++ b/Validation/nightly/ceMix_04.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_05.fcl
+++ b/Validation/nightly/ceMix_05.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_06.fcl
+++ b/Validation/nightly/ceMix_06.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_07.fcl
+++ b/Validation/nightly/ceMix_07.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_08.fcl
+++ b/Validation/nightly/ceMix_08.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_09.fcl
+++ b/Validation/nightly/ceMix_09.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_10.fcl
+++ b/Validation/nightly/ceMix_10.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_11.fcl
+++ b/Validation/nightly/ceMix_11.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_12.fcl
+++ b/Validation/nightly/ceMix_12.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_13.fcl
+++ b/Validation/nightly/ceMix_13.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_14.fcl
+++ b/Validation/nightly/ceMix_14.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_15.fcl
+++ b/Validation/nightly/ceMix_15.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_16.fcl
+++ b/Validation/nightly/ceMix_16.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_17.fcl
+++ b/Validation/nightly/ceMix_17.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_18.fcl
+++ b/Validation/nightly/ceMix_18.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_19.fcl
+++ b/Validation/nightly/ceMix_19.fcl
@@ -4,9 +4,6 @@ physics.filters.MuBeamFlashMixer.mu2e.MaxEventsToSkip: 1113148
 physics.filters.EleBeamFlashMixer.mu2e.MaxEventsToSkip: 25650
 physics.filters.NeutralsFlashMixer.mu2e.MaxEventsToSkip: 91132
 physics.filters.MuStopPileupMixer.mu2e.MaxEventsToSkip: 872769
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_0
-services.DbService.verbose : 2
 services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 outputs.TriggeredOutput.fileName: "dig.owner.CeEndpointMix1BBTriggered.version.sequencer.art"
 

--- a/Validation/nightly/ceMix_epilog.fcl
+++ b/Validation/nightly/ceMix_epilog.fcl
@@ -1,3 +1,4 @@
+#include "Production/Validation/database.fcl"
 
 services.TFileService.fileName: "/dev/null"
 

--- a/Validation/nightly/extracted_00.fcl
+++ b/Validation/nightly/extracted_00.fcl
@@ -1,6 +1,6 @@
 #include "Production/JobConfig/reco/Extracted.fcl"
 services.DbService.purpose: MDC2020_perfect
-services.DbService.version: v1_0
+services.DbService.version: v1_3
 services.DbService.verbose : 2
 
 #----------------------------------------------------------------

--- a/Validation/nightly/extracted_00.fcl
+++ b/Validation/nightly/extracted_00.fcl
@@ -1,7 +1,5 @@
 #include "Production/JobConfig/reco/Extracted.fcl"
-services.DbService.purpose: MDC2020_perfect
-services.DbService.version: v1_3
-services.DbService.verbose : 2
+#include "Production/Validation/database.fcl"
 
 #----------------------------------------------------------------
 # Code added by generate_fcl:

--- a/Validation/nightly/extracted_01.fcl
+++ b/Validation/nightly/extracted_01.fcl
@@ -1,6 +1,6 @@
 #include "Production/JobConfig/reco/Extracted.fcl"
 services.DbService.purpose: MDC2020_perfect
-services.DbService.version: v1_0
+services.DbService.version: v1_3
 services.DbService.verbose : 2
 
 #----------------------------------------------------------------

--- a/Validation/nightly/extracted_01.fcl
+++ b/Validation/nightly/extracted_01.fcl
@@ -1,7 +1,5 @@
 #include "Production/JobConfig/reco/Extracted.fcl"
-services.DbService.purpose: MDC2020_perfect
-services.DbService.version: v1_3
-services.DbService.verbose : 2
+#include "Production/Validation/database.fcl"
 
 #----------------------------------------------------------------
 # Code added by generate_fcl:

--- a/Validation/nightly/extracted_02.fcl
+++ b/Validation/nightly/extracted_02.fcl
@@ -1,6 +1,6 @@
 #include "Production/JobConfig/reco/Extracted.fcl"
 services.DbService.purpose: MDC2020_perfect
-services.DbService.version: v1_0
+services.DbService.version: v1_3
 services.DbService.verbose : 2
 
 #----------------------------------------------------------------

--- a/Validation/nightly/extracted_02.fcl
+++ b/Validation/nightly/extracted_02.fcl
@@ -1,7 +1,5 @@
 #include "Production/JobConfig/reco/Extracted.fcl"
-services.DbService.purpose: MDC2020_perfect
-services.DbService.version: v1_3
-services.DbService.verbose : 2
+#include "Production/Validation/database.fcl"
 
 #----------------------------------------------------------------
 # Code added by generate_fcl:

--- a/Validation/nightly/extracted_03.fcl
+++ b/Validation/nightly/extracted_03.fcl
@@ -1,6 +1,6 @@
 #include "Production/JobConfig/reco/Extracted.fcl"
 services.DbService.purpose: MDC2020_perfect
-services.DbService.version: v1_0
+services.DbService.version: v1_3
 services.DbService.verbose : 2
 
 #----------------------------------------------------------------

--- a/Validation/nightly/extracted_03.fcl
+++ b/Validation/nightly/extracted_03.fcl
@@ -1,7 +1,5 @@
 #include "Production/JobConfig/reco/Extracted.fcl"
-services.DbService.purpose: MDC2020_perfect
-services.DbService.version: v1_3
-services.DbService.verbose : 2
+#include "Production/Validation/database.fcl"
 
 #----------------------------------------------------------------
 # Code added by generate_fcl:

--- a/Validation/nightly/extracted_04.fcl
+++ b/Validation/nightly/extracted_04.fcl
@@ -1,6 +1,6 @@
 #include "Production/JobConfig/reco/Extracted.fcl"
 services.DbService.purpose: MDC2020_perfect
-services.DbService.version: v1_0
+services.DbService.version: v1_3
 services.DbService.verbose : 2
 
 #----------------------------------------------------------------

--- a/Validation/nightly/extracted_04.fcl
+++ b/Validation/nightly/extracted_04.fcl
@@ -1,7 +1,5 @@
 #include "Production/JobConfig/reco/Extracted.fcl"
-services.DbService.purpose: MDC2020_perfect
-services.DbService.version: v1_3
-services.DbService.verbose : 2
+#include "Production/Validation/database.fcl"
 
 #----------------------------------------------------------------
 # Code added by generate_fcl:

--- a/Validation/trigger.fcl
+++ b/Validation/trigger.fcl
@@ -8,9 +8,7 @@
 #include "mu2e_trig_config/gen/trig_valMenu_OnSpill.fcl"
 process_name : OnSpillTrigger
 services : @local::Services.Reco
-services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_2
-services.DbService.verbose : 2
+#include "Production/Validation/database.fcl"
 
 source : { module_type : RootInput }
 physics : {

--- a/Validation/trigger.fcl
+++ b/Validation/trigger.fcl
@@ -9,7 +9,7 @@
 process_name : OnSpillTrigger
 services : @local::Services.Reco
 services.DbService.purpose: MDC2020_best
-services.DbService.version: v1_1
+services.DbService.version: v1_2
 services.DbService.verbose : 2
 
 source : { module_type : RootInput }


### PR DESCRIPTION
Includes new CRV tables and AlignedTrackerSim tables. AlignedTracker reco tables updated to include sim wire offsets. Should be merged at the same time as corresponding Offline PR enabling AlignedTrackerSim db use

It is expected that reco performance (chi2/dof etc.) will look slightly worse in validation.

Note that trigger validation has also been moved to v1_2 but is running still on v1_0 digis.