### PR TITLE
update IPAMuminusMichel primary generator and prefilter

### DIFF
--- a/JobConfig/primary/IPAMuminusMichel.fcl
+++ b/JobConfig/primary/IPAMuminusMichel.fcl
@@ -5,14 +5,13 @@
 # original author: S Middleton
 #
 #include "Production/JobConfig/primary/IPAStopParticle.fcl"
-
 physics.filters.PrimaryFilter.MinimumPartMom : 1.0
 physics.producers.FindMCPrimary.PrimaryProcess : "mu2eMuonDecayAtRest"
 
-CompositeGenerator: {
+physics.producers.generate: {
   module_type: CompositeMaterialGenerator
-  tag: IPAMuminusStopResampler
-  process: "mu2eMuonDecayAtRest"
+  SimParticleCollection: IPAMuminusStopResampler
+  processCode: "mu2eMuonDecayAtRest"
   weighting: {
     tool_type: AtomicVolumeSamplerTool
     material: "IPAPolyethylene"
@@ -56,7 +55,5 @@ CompositeGenerator: {
     }
   ]
 }
-
-physics.producers.generate: @local::CompositeGenerator
 
 outputs.PrimaryOutput.fileName: "dts.owner.IPAMuminusMichel.version.sequencer.art"

--- a/JobConfig/primary/IPAMuminusMichel.fcl
+++ b/JobConfig/primary/IPAMuminusMichel.fcl
@@ -13,7 +13,7 @@ physics.producers.generate: {
   SimParticleCollection: IPAMuminusStopResampler
   processCode: "mu2eMuonDecayAtRest"
   weighting: {
-    tool_type: AtomicVolumeSamplerTool
+    tool_type: BoundMuonDecayFractionSamplerTool
     material: "IPAPolyethylene"
   }
   elements: [

--- a/JobConfig/primary/IPAMuminusMichel.fcl
+++ b/JobConfig/primary/IPAMuminusMichel.fcl
@@ -6,16 +6,57 @@
 #
 #include "Production/JobConfig/primary/IPAStopParticle.fcl"
 
-physics.filters.PrimaryFilter.MinimumPartMom : 30.0 // MeV/c TODO - tweak this parameter to get more DetSteps
+physics.filters.PrimaryFilter.MinimumPartMom : 1.0
 physics.producers.FindMCPrimary.PrimaryProcess : "mu2eMuonDecayAtRest"
 
-physics.producers.generate : {
-  module_type : Pileup
-  verbosity : 0
-  inputSimParticles: IPAMuminusStopResampler
-  captureProducts : []
-  decayProducts : [ @local::Pileup.dioGenTool ]
-  stoppingTargetMaterial : "IPA"
+CompositeGenerator: {
+  module_type: CompositeMaterialGenerator
+  tag: IPAMuminusStopResampler
+  process: "mu2eMuonDecayAtRest"
+  weighting: {
+    tool_type: AtomicVolumeSamplerTool
+    material: "IPAPolyethylene"
+  }
+  elements: [
+    {
+      name: "C"
+      position_tool: {
+        tool_type: MuStopDecayPositionSamplerTool
+        atom: "C"
+      }
+      generator_tool: {
+        tool_type: DIOGenerator
+        spectrum: {
+          pdgId: 11
+          spectrumShape: "tabulated"
+          spectrumVariable: "totalEnergy"
+          spectrumFileName: "Offline/ConditionsService/data/heeck_finer_binning_2016_szafron-scaled-to-6C.tbl"
+          elow: 1.0
+          ehi: 110.0
+        }
+      }
+    },
+    {
+      name: "H"
+      position_tool: {
+        tool_type: MuStopDecayPositionSamplerTool
+        atom: "H"
+      }
+      generator_tool: {
+        tool_type: DIOGenerator
+        spectrum: {
+          pdgId: 11
+          spectrumShape: "tabulated"
+          spectrumVariable: "totalEnergy"
+          spectrumFileName: "Offline/ConditionsService/data/heeck_finer_binning_2016_szafron-scaled-to-1H.tbl"
+          elow: 1.0
+          ehi: 110.0
+        }
+      }
+    }
+  ]
 }
+
+physics.producers.generate: @local::CompositeGenerator
 
 outputs.PrimaryOutput.fileName: "dts.owner.IPAMuminusMichel.version.sequencer.art"

--- a/JobConfig/primary/IPAStopParticle.fcl
+++ b/JobConfig/primary/IPAStopParticle.fcl
@@ -5,7 +5,13 @@
 #
 #include "Production/JobConfig/primary/StopParticle.fcl"
 
-physics.PrimaryPath : [ IPAMuminusStopResampler, @sequence::Common.generateSequence, @sequence::Common.g4Sequence, @sequence::Primary.PrimarySequence ]
+physics.filters.TrackerRadialGenFilter: {
+  @table::GenFilter
+  isNull: false
+  maxr_min: 350.0 # tracker acceptance begins at ~400 mm
+}
+
+physics.PrimaryPath : [ IPAMuminusStopResampler, @sequence::Common.generateSequence, TrackerRadialGenFilter, @sequence::Common.g4Sequence, @sequence::Primary.PrimarySequence ]
 physics.trigger_paths : [ PrimaryPath ]
 outputs : { PrimaryOutput :@local::Primary.PrimaryOutput }
 physics.EndPath : [ @sequence::Primary.EndSequence, PrimaryOutput ]


### PR DESCRIPTION
This PR updates the configuration for `IPAMuminusMichel` primary jobs to use a new (and as-yet unmerged) generator which accommodates heterogeneous materials. The configuration implemented here samples muons which stopped in the IPA volume, and chooses which element the muon captured into according to the relative atomic volumes of carbon and hydrogen. The chosen element then defines the decay-time distribution and DIO spectrum associated with the most-abundant nucleus, respectively. The fcl files produced using `gen_Primary.sh` have been tested to run without error, but depend on https://github.com/Mu2e/Offline/pull/1290.

This PR also makes use of Sophie's `GenFilter` to prefilter out electrons which have trajectory which will never intersect a tracker straw, which will lead to savings in cpu consumption.