### PR TITLE
SurfaceStep Compression Configuration

### DIFF
--- a/JobConfig/digitize/prolog.fcl
+++ b/JobConfig/digitize/prolog.fcl
@@ -35,6 +35,7 @@ Digitize: {
       caloShowerStepTags : @local::DigiCompressionTags.primaryCaloShowerStepTags
       caloShowerSimTag : @local::DigiCompressionTags.commonCaloShowerSimTag
       caloShowerROTag : @local::DigiCompressionTags.commonCaloShowerROTag
+      surfaceStepTags : [ "compressDetStepMCs" ]
       primaryParticleTag : "FindMCPrimary"
       keepAllGenParticles : true
       rekeySimParticleCollection : true

--- a/JobConfig/primary/prolog.fcl
+++ b/JobConfig/primary/prolog.fcl
@@ -6,6 +6,7 @@
 #include "Offline/CRVResponse/fcl/prolog.fcl"
 #include "Offline/Filters/fcl/prolog.fcl"
 #include "Offline/Compression/fcl/prolog.fcl"
+#include "Offline/CommonMC/fcl/prolog.fcl"
 #
 BEGIN_PROLOG
 
@@ -17,11 +18,18 @@ Primary: {
       @table::CrvSteps
       stepPointsModuleLabels : ["g4run"]
     }
+    SurfaceSteps : {
+      @table::CommonMC.MakeSS
+      VDStepPointMCs : "g4run:virtualdetector"
+      IPAStepPointMCs : "g4run:protonabsorber"
+      TargetStepPointMCs : "g4run:stoppingtarget"
+    }
     compressDetStepMCs : {
       module_type : CompressDetStepMCs
       strawGasStepTag : "StrawGasStepMaker"
       caloShowerStepTag : "CaloShowerStepMaker"
       crvStepTag : "CrvSteps"
+      surfaceStepTag : "SurfaceSteps"
       simParticleTags : [ "g4run" ]
       mcTrajectoryTag : "g4run"
       debugLevel : 0
@@ -148,7 +156,8 @@ Primary: {
   DetStepSequence : [
     @sequence::TrackerMC.StepSim,
     @sequence::CaloMC.StepSim,
-    CrvSteps ]
+    CrvSteps,
+    SurfaceSteps ]
   # sequence to finalize the output
   FinalizeSequence : [  compressDetStepMCs, FindMCPrimary ]
 
@@ -156,6 +165,7 @@ Primary: {
     "keep mu2e::StrawGasSteps_compressDetStepMCs_*_*",
     "keep mu2e::CaloShowerSteps_compressDetStepMCs_*_*",
     "keep mu2e::CrvSteps_compressDetStepMCs_*_*",
+    "keep mu2e::SurfaceSteps_*_*_*",
     "keep mu2e::StepPointMCs_compressDetStepMCs_virtualdetector_*",
     "keep mu2e::StepPointMCs_compressDetStepMCs_protonabsorber_*",
     "keep mu2e::StepPointMCs_compressDetStepMCs_stoppingtarget_*",

--- a/JobConfig/reco/prolog.fcl
+++ b/JobConfig/reco/prolog.fcl
@@ -181,6 +181,7 @@ Reconstruction : {
       crvDigiMCTag : "compressDigiMCs"
       simParticleTags : [ "compressDigiMCs" ]
       extraStepPointMCTags : ["compressDigiMCs:virtualdetector", "compressDigiMCs:stoppingtarget", "compressDigiMCs:protonabsorber" ]
+      surfaceStepTags : [ "compressDigiMCs" ]
       caloShowerStepTags : [ ]
       caloShowerSimTag : ""
       caloShowerROTag : ""


### PR DESCRIPTION
This PR goes with Mu2e/Offline#1306. At the moment, I have done the following (there are some questions):

 - added a MakeSurfaceSteps configuration to the primary prolog.fcl
    - do we want this done at this early stage? if we are not going to regenerate other DetectorSteps, we could move it into the digitization stage
 - added SurfaceStep ```noCompression``` compression at the end of the primary stage
   - do we want to do any actual compression at this early stage? I don't think so but let me know if you disagree
 - added SurfaceStep compression to the digi and reco stages where we only keep the SurfaceStep if we are keeping the associated SimParticle
    - again, I think this is what we want but let me know if not

And some things I haven't done:
 - dropped StepPointMCs from any output
   - will this affect any validation?
 - added SurfaceSteps for mixed background frames
   - see below

On this latter point, the SurfaceSteps are smaller in size than the StepPointMCs so there may be some space to add SurfaceSteps for pileup processes. From ```product_sizes_dumper``` output of a 5-event dts file:
 - SurfaceSteps: 1.4 kB / event
 - all StepPointMCs: 9.0 kB / event

```
Size in bytes   Fraction Data Product Name
             51304      0.342 mu2e::SimParticleart::Ptrmu2e::MCTrajectorystd::map_compressDetStepMCs__Primary.
             25320      0.169 mu2e::StepPointMCs_compressDetStepMCs_stoppingtarget_Primary.
             17303      0.115 mu2e::StrawGasSteps_compressDetStepMCs__Primary.
             13132      0.087 mu2e::SimParticlemv_compressDetStepMCs__Primary.
             11142      0.074 mu2e::StepPointMCs_compressDetStepMCs_virtualdetector_Primary.
              8677      0.058 mu2e::StepPointMCs_compressDetStepMCs_protonabsorber_Primary.
              7873      0.052 mu2e::CaloShowerSteps_compressDetStepMCs__Primary.
              6952      0.046 mu2e::SurfaceSteps_compressDetStepMCs__Primary.
              6910      0.046 mu2e::SurfaceSteps_SurfaceSteps__Primary.
              1339      0.009 mu2e::GenParticles_compressDetStepMCs__Primary.
              1139      0.008 mu2e::PrimaryParticle_FindMCPrimary__Primary.
              1128      0.008 art::EventIDs_TargetStopResampler__Primary.
              1121      0.007 art::TriggerResults_TriggerResults__Primary.
              1096      0.007 mu2e::CrvSteps_compressDetStepMCs__Primary.
              1074      0.007 mu2e::StatusG4_g4run__Primary.
               460      0.003 EventAuxiliary
------------------------------
            155970      1.039 Total
```