### PR TITLE
Add missing KKUeM to SelectRecoMC KalSeedMCAssns

### DIFF
--- a/JobConfig/reco/prolog.fcl
+++ b/JobConfig/reco/prolog.fcl
@@ -167,7 +167,7 @@ Reconstruction : {
       CrvDigiMCCollection : "compressDigiMCs"
       KalSeedCollections  : [
         "KKDeM", "KKDeP", "KKDmuM", "KKDmuP",
-        "KKUeM", "KKUmuP", "KKUmuM", "KKUmuP",
+        "KKUeM", "KKUeP", "KKUmuM", "KKUmuP",
         "KKLine","KKOffSpill"]
       HelixSeedCollections  : ["MHDeM", "MHDeP", "MHDmuM", "MHDmuP",
         "MHUeM", "MHUeP", "MHUmuM", "MHUmuP" ]


### PR DESCRIPTION
While looking at the new EventNtuples, I noticed that sometimes there were different numbers of elements in the ```trk``` branch than in the ```trkmc``` branch:

```
root [2] ntuple->Scan("trk.nhits:trkmc.nhits")
***********************************************
*    Row   * Instance * trk.nhits * trkmc.nhi *
***********************************************
*       15 *        0 *        51 *        48 *
*       15 *        1 *        28 *        28 *
*       15 *        2 *        51 *        48 *
*       15 *        3 *        51 *        27 *
*       15 *        4 *        27 *        31 *
*       15 *        5 *        31 *        47 *
*       15 *        6 *        50 *           *
***********************************************
```

After some debugging, I tracked this down to the fact that KKUeP tracks are missing from the Assns that associates KalSeeds to KalSeedMCs. It looks like a simple typo in the SelectRecoMC configuration: we are missing KKUeP and have KKUmuP twice.

I've tested this change locally and now get the expected result:
```
root [2] ntuple->Scan("trk.nhits:trkmc.nhits")
***********************************************
*    Row   * Instance * trk.nhits * trkmc.nhi *
***********************************************
*       15 *        0 *        51 *        48 *
*       15 *        1 *        28 *        28 *
*       15 *        2 *        51 *        48 *
*       15 *        3 *        51 *        48 *
*       15 *        4 *        27 *        27 *
*       15 *        5 *        31 *        31 *
*       15 *        6 *        50 *        47 *
***********************************************
```