### PR TITLE
added option to deal with older CrvDigis in Validation

### DIFF
--- a/Validation/reco.fcl
+++ b/Validation/reco.fcl
@@ -20,6 +20,7 @@ physics.RecoPath : [
 ]
 physics.producers.SelectRecoMC.KalSeedCollections : [ "KKDeM", "KKDeP"]
 physics.producers.SelectRecoMC.HelixSeedCollections  : ["MHDeM", "MHDeP" ]
+physics.producers.CrvRecoPulses.oldDigis : true
 physics.filters.RecoFilter.TrkTags : [ "KKDeM", "KKDeP"]
 physics.filters.RecoFilter.MomentumCutoff : [ 60.0, 60.0 ]
 


### PR DESCRIPTION
- old digis were produced relative to -protonBunchTime
- new digis are produced relative to -protonBunchTime-eventTiming.timeFromProtonsToDRMarker

The fcl setting `physics.producers.CrvRecoPulses.oldDigis : true` allows us to read old digis with the new code. This setting is used for the nightly validation job "reco", so that we can continue to use the CrvDigis of the MDC2020 files.