### PR TITLE
explicit dts InputTags for tracker digi maker configuration

### DIFF
--- a/JobConfig/digitize/epilog.fcl
+++ b/JobConfig/digitize/epilog.fcl
@@ -1,5 +1,5 @@
 # Module labels needed for compressed detector steps
-physics.producers.makeSD.StrawGasStepModule : "compressDetStepMCs"
+physics.producers.makeSD.StrawGasStepModules : [ "compressDetStepMCs" ]
 physics.producers.CaloShowerROMaker.caloShowerStepCollection : ["compressDetStepMCs"]
 physics.producers.compressDigiMCs.simParticleTags : ["compressDetStepMCs"]
 physics.producers.compressDigiMCs.caloShowerStepTags : ["compressDetStepMCs"]

--- a/JobConfig/mixing/epilog.fcl
+++ b/JobConfig/mixing/epilog.fcl
@@ -7,7 +7,7 @@ physics.filters.NeutralsFlashMixer.mu2e.simStageEfficiencyTags: ["NeutralsCat", 
 physics.filters.MuStopPileupMixer.mu2e.simStageEfficiencyTags: ["MuBeamCat", "MuminusStopsCat", "MuStopPileupCat"]
 physics.filters.MuStopPileupMixer.mu2e.meanEventsPerPOTFactors : [ @local::Pileup.MuminusTargetStopPrescale ]
 # adjust detstep lists to include pileup
-physics.producers.makeSD.StrawGasStepModule : ""
+physics.producers.makeSD.StrawGasStepModules : [ "EleBeamFlashMixer", "MuBeamFlashMixer", "NeutralsFlashMixer", "MuStopPileupMixer" ]
 physics.producers.compressDigiMCs.simParticleTags : [compressDetStepMCs, @sequence::Mixing.StepMixSequence ]
 physics.producers.compressDigiMCs.caloShowerStepTags : [compressDetStepMCs, @sequence::Mixing.StepMixSequence ]
 physics.producers.CaloShowerROMaker.caloShowerStepCollection : [compressDetStepMCs, @sequence::Mixing.StepMixSequence ]

--- a/JobConfig/mixing/epilog.fcl
+++ b/JobConfig/mixing/epilog.fcl
@@ -7,7 +7,7 @@ physics.filters.NeutralsFlashMixer.mu2e.simStageEfficiencyTags: ["NeutralsCat", 
 physics.filters.MuStopPileupMixer.mu2e.simStageEfficiencyTags: ["MuBeamCat", "MuminusStopsCat", "MuStopPileupCat"]
 physics.filters.MuStopPileupMixer.mu2e.meanEventsPerPOTFactors : [ @local::Pileup.MuminusTargetStopPrescale ]
 # adjust detstep lists to include pileup
-physics.producers.makeSD.StrawGasStepModules : [ "EleBeamFlashMixer", "MuBeamFlashMixer", "NeutralsFlashMixer", "MuStopPileupMixer" ]
+physics.producers.makeSD.StrawGasStepModules : [ compressDetStepMCs, @sequence::Mixing.StepMixSequence ]
 physics.producers.compressDigiMCs.simParticleTags : [compressDetStepMCs, @sequence::Mixing.StepMixSequence ]
 physics.producers.compressDigiMCs.caloShowerStepTags : [compressDetStepMCs, @sequence::Mixing.StepMixSequence ]
 physics.producers.CaloShowerROMaker.caloShowerStepCollection : [compressDetStepMCs, @sequence::Mixing.StepMixSequence ]

--- a/Validation/cosmicSimReco.fcl
+++ b/Validation/cosmicSimReco.fcl
@@ -122,7 +122,7 @@ physics.producers.g4run.Mu2eG4CommonCut: @local::Cosmic.Mu2eG4CommonCutCosmicNoF
 physics.producers.CrvPhotons.crvStepModuleLabels  : ["CrvSteps"]
 physics.producers.CrvPhotons.crvStepProcessNames  : ["cosmicSimReco"]
 
-physics.producers.makeSD.StrawGasStepModule : "StrawGasStepMaker"
+physics.producers.makeSD.StrawGasStepModules : [ "StrawGasStepMaker" ]
 physics.producers.CaloShowerROMaker.caloShowerStepCollection : [ "CaloShowerStepMaker" ]
 # turn off very verbose
 physics.producers.CrvCoincidence.verboseLevel : 0


### PR DESCRIPTION
This PR adapts the configuration of the tracker digi maker, i.e. "`makeSD`," to that implemented in https://github.com/Mu2e/Offline/pull/1366. This is a preparatory change for the implementation of runtime-filtering of mixed detector steps.