### PR TITLE
Add flat RMC photon conversion saving production fcl

### DIFF
--- a/JobConfig/primary/RMCFlatGammaReader.fcl
+++ b/JobConfig/primary/RMCFlatGammaReader.fcl
@@ -1,0 +1,6 @@
+#
+# RMC External photons, flat energy spectrum, resampling events with a photon conversion
+#
+
+#include "Production/JobConfig/primary/RMCGammaReader.fcl"
+outputs.PrimaryOutput.fileName : "dts.owner.RMCFlatGammaReader.version.sequencer.art"

--- a/JobConfig/primary/RMCFlatGammaWriter.fcl
+++ b/JobConfig/primary/RMCFlatGammaWriter.fcl
@@ -1,0 +1,24 @@
+#
+# RMC External photons with a flat energy spectrum, saving events with a photon conversion for resampling purposes
+#
+
+#include "Production/JobConfig/primary/RMCGammaWriter.fcl"
+
+outputs.TargetOutput.fileName : "sim.owner.RMCFlatGammaWriter.version.sequencer.art"
+outputs.WireOutput.fileName   : "sim.owner.RMCFlatWireGammaWriter.version.sequencer.art"
+outputs.IPAOutput.fileName    : "sim.owner.RMCFlatIPAGammaWriter.version.sequencer.art"
+
+#------------------------------------------------------------------------
+# Generation configuration
+
+physics.producers.generate : {
+  module_type            : FlatMuonDaughterGenerator
+  inputSimParticles      : TargetStopResampler
+  stoppingTargetMaterial : "Al"
+  pdgId                  : 22
+  startMom               : 80
+  endMom                 : 102
+  verbosity              : 0
+}
+physics.producers.FindMCPrimary.PrimaryProcess    : "mu2eFlatPhoton"
+physics.filters.GammaConversionFilter.processCode : "mu2eFlatPhoton"

--- a/JobConfig/primary/prolog.fcl
+++ b/JobConfig/primary/prolog.fcl
@@ -162,7 +162,7 @@ Primary: {
 	zMax : 8000.
 	eMin : 1.5
 	verbosity : 0
-	saveTree : true
+	saveTree : false
     }
   }
 

--- a/Tests/RMCFlatGammaWriter.fcl
+++ b/Tests/RMCFlatGammaWriter.fcl
@@ -1,0 +1,2 @@
+#include "Production/JobConfig/primary/RMCFlatGammaWriter.fcl"
+#include "Production/Tests/MuonStopConfig.fcl"


### PR DESCRIPTION
Add fcl to produce an RMC photon conversion point dataset using a flat photon energy spectrum. This will be useful for RMC spectrum measurement and unfolding studies using photon pair conversions in the stopping target wires and IPA. It can also be used for estimating the RMC background from asymmetric real photon conversions.