### PR TITLE
Add a test stopping target antiproton processing for studies

### DIFF
--- a/JobConfig/beam/SimpleAntiprotons.fcl
+++ b/JobConfig/beam/SimpleAntiprotons.fcl
@@ -1,0 +1,89 @@
+# Shoot antiprotons directly at the stopping target for antiproton studies
+# Original author: Michael MacKenzie (2025)
+
+#include "Offline/fcl/standardServices.fcl"
+#include "Offline/EventGenerator/fcl/prolog.fcl"
+#include "Production/JobConfig/common/prolog.fcl"
+#include "Production/JobConfig/beam/prolog.fcl"
+
+process_name : SimpleAntiprotons
+
+source : {
+    module_type : EmptyEvent
+    maxEvents : @nil
+}
+
+services : @local::Services.Sim
+
+physics : {
+    # setup the modules
+    producers: {
+        @table::Common.producers
+        generate: {
+            module_type : SimpleAntiprotonGun
+	    t0          :  400.
+	    tmax        : 2000.
+            pzmax       :  100.
+        }
+        compressPVTGTStops: {
+            module_type: CompressPhysicalVolumes
+            volumesInput : "g4run"
+            hitInputs : []
+            particleInputs : [ "tgtStopFilter" ]
+        }
+        stoppedAntiprotonFinder : {
+            module_type : StoppedParticlesFinder
+            particleInput : "g4run"
+            # multiple matches, we'll get the one from the current process, which is what we want
+            physVolInfoInput : "g4run"
+            stoppingMaterial : "StoppingTarget_Al"
+            particleTypes : [ -2212 ] # pbar
+            verbosityLevel: 1
+        }
+    }
+    filters: {
+        @table::Common.filters
+        tgtStopFilter: {
+            module_type: FilterG4Out
+            mainHitInputs: []
+            extraHitInputs: [ "g4run:virtualdetector" ]
+            mainSPPtrInputs: [ "stoppedAntiprotonFinder" ]
+        }
+    }
+    analyzers : @local::Common.analyzers
+
+    # setup the paths
+    tgtFilter : [ @sequence::Common.generateSequence, @sequence::Common.g4Sequence, stoppedAntiprotonFinder, tgtStopFilter, compressPVTGTStops]
+    trigger_paths : [tgtFilter]
+    LogPath : [ genCountLogger ]
+    OutputPath : [ tgtStopOutput ]
+    end_paths : [OutputPath, LogPath ]
+}
+
+# setup outputs
+outputs: {
+    tgtStopOutput : {
+        module_type : RootOutput
+        SelectEvents : [ tgtFilter ]
+        outputCommands :   [ "drop *_*_*_*",
+                             "keep mu2e::GenParticles_*_*_*",
+                             "keep mu2e::GenEventCount_*_*_*",
+                             "keep mu2e::StatusG4_*_*_*",
+                             "keep *_tgtStopFilter_*_*",
+                             "keep *_compressPVTGTStops_*_*"
+                            ]
+        fileName : "sim.owner.stoppedSimpleAntiprotons.version.sequencer.art"
+    }
+}
+
+physics.producers.g4run.SDConfig.enableSD: [ virtualdetector ] # only VDs are active
+
+#include "Production/JobConfig/beam/epilog.fcl"
+#include "Production/JobConfig/common/epilog.fcl"
+
+# restricted BField for efficiency
+services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
+
+# the following is overwritten by generate_fcl
+services.SeedService.baseSeed : @local::Common.BaseSeed
+

--- a/JobConfig/primary/AntiprotonStop.fcl
+++ b/JobConfig/primary/AntiprotonStop.fcl
@@ -1,0 +1,29 @@
+#
+# Configuration for resampling target antiproton stops
+#
+# Original author: Michael MacKenzie (2025)
+#
+#include "Production/JobConfig/primary/TargetStopParticle.fcl"
+
+physics.producers.generate : {
+    module_type       : AntiprotonResampling
+    inputSimParticles : "TargetStopResampler"
+}
+
+physics.filters.TargetStopResampler.mu2e.products : {
+    genParticleMixer: { mixingMap: [ [ "generate", "" ] ] }
+    simParticleMixer: { mixingMap: [ [ "tgtStopFilter", "" ] ] }
+    stepPointMCMixer: { mixingMap: [ [ "tgtStopFilter:virtualdetector", ":" ] ] }
+    volumeInfoMixer: {
+        srInput: "compressPVTGTStops"
+        evtOutInstanceName: "eventlevel"
+    }
+}
+
+# Reduce the primary filter cuts
+physics.filters.PrimaryFilter.MinimumPartMom : 40.
+
+physics.producers.g4run.inputs.simStageOverride : 1
+
+physics.producers.FindMCPrimary.PrimaryProcess : mu2eAntiproton
+outputs.PrimaryOutput.fileName: "dts.owner.AntiprotonStop.version.sequencer.art"

--- a/Tests/AntiprotonStopSteps.fcl
+++ b/Tests/AntiprotonStopSteps.fcl
@@ -1,0 +1,10 @@
+#include "Production/JobConfig/primary/AntiprotonStop.fcl"
+#include "Production/Tests/MuonStopConfig.fcl"
+
+# Test file generated with Production/JobConfig/beam/SimpleAntiprotons.fcl
+physics.filters.TargetStopResampler.fileNames : ["sim.owner.stoppedSimpleAntiprotons.version.sequencer.art"]
+
+# Add histograms and some extra output
+physics.producers.generate.makeHistograms : true
+physics.producers.generate.verbosity : 1
+services.TFileService.fileName: "nts.owner.AntiprotonStop.version.sequencer.root"


### PR DESCRIPTION
Add a production workflow for the simple antiproton gun. This generates antiprotons just upstream of the stopping target, moving downstream. The antiproton stops are saved and then resampled. This may be useful for antiproton reconstruction algorithm development as well as general multitrack algorithm development, but is not meant for antiproton background estimation as the antiproton distributions are not physical.