### PR TITLE
Tweak OffSpill digitization

### DIFF
--- a/JobConfig/digitize/Extracted.fcl
+++ b/JobConfig/digitize/Extracted.fcl
@@ -17,9 +17,7 @@ outputs.TriggeredOutput.SelectEvents : [
 services.GeometryService.inputFile: "Offline/Mu2eG4/geom/geom_common_extracted.txt"
 services.GeometryService.bFieldFile: "Offline/Mu2eG4/geom/bfgeom_no_field.txt"
 # override some prescales
-physics.filters.TriggerablePrescale.prescaleFactor : 100 # only record 1% of the untriggered
 physics.filters.TriggerableCHEnable.ReturnValue : true # enable high mom triggerable
-physics.filters.TriggerableCHPrescale.prescaleFactor : 100 # only record 1% of the untriggered
 # set the spill type
 physics.producers.EWMProducer.SpillType : 0
 # Temporarily turn off Crv noise

--- a/JobConfig/digitize/Extracted.fcl
+++ b/JobConfig/digitize/Extracted.fcl
@@ -1,28 +1,6 @@
 # configure Extracted digitization
-# first, trigger filtesr and paths
-#include "mu2e_trig_config/gen/trig_extrPosMenuPSConfig.fcl"
-#include "mu2e_trig_config/gen/trig_extrPosMenu.fcl"
-# then generic digitization
-#include "Production/JobConfig/digitize/Digitize.fcl"
-# add trigger filters
-physics.filters : { @table::physics.filters @table::Trig_extrPosMenuPSConfig }
-# add the trigger paths
-physics.trigger_paths : [ @sequence::Digitize.trigger_paths, @sequence::Trig_extrPosMenu.trigger_paths]
-# configure 'Triggered' output to be calibration triggers
-outputs.TriggeredOutput.SelectEvents : [
-  @sequence::Digitize.TrkTriggers,
-  @sequence::Digitize.CaloTriggers ]
-# extracted-specific overrides
-# extracted geometry
+#include "Production/JobConfig/digitize/NoField.fcl"
+# use extracted geometry
 services.GeometryService.inputFile: "Offline/Mu2eG4/geom/geom_common_extracted.txt"
-services.GeometryService.bFieldFile: "Offline/Mu2eG4/geom/bfgeom_no_field.txt"
-# override some prescales
-physics.filters.TriggerableCHEnable.ReturnValue : true # enable high mom triggerable
-# set the spill type
-physics.producers.EWMProducer.SpillType : 0
-# Temporarily turn off Crv noise
-physics.producers.CrvSiPMCharges.ThermalRate : 0
-# same for calorimeter
-physics.producers.CaloDigiMaker.addNoise : false
 # override CRV lookup tables, photon yields, etc. for the extracted position
 #include "Offline/CRVResponse/fcl/epilog_extracted.fcl"

--- a/JobConfig/digitize/MakeSurfaceSteps.fcl
+++ b/JobConfig/digitize/MakeSurfaceSteps.fcl
@@ -2,15 +2,4 @@
 # This script is a patch to allow digitizing existing MDC2020 dts files, which do not have SurfaceSteps in them.
 # it should be sourced as epilog after digitization
 #
-physics.producers.MakeSS : {
-  @table::CommonMC.MakeSS
-  VDStepPointMCs : "compressDetStepMCs:virtualdetector"
-  AbsorberStepPointMCs : "compressDetStepMCs:protonabsorber"
-  TargetStepPointMCs : "compressDetStepMCs:stoppingtarget"
-}
 physics.producers.compressDigiMCs.surfaceStepTags : [ "MakeSS" ]
-physics.DigitizePath : [ "MakeSS" , @sequence::physics.DigitizePath ]
-physics.TriggerablePath : [ "MakeSS" , @sequence::physics.TriggerablePath ]
-physics.TriggerableCHPath : [ "MakeSS" , @sequence::physics.TriggerablePath ]
-
-

--- a/JobConfig/digitize/NoField.fcl
+++ b/JobConfig/digitize/NoField.fcl
@@ -1,22 +1,28 @@
 # configure NoField digitization
-# add trigger paths; for now use the Extracted trigger menu, as these assume no field (should become renamed TODO
-#include "mu2e_trig_config/gen/trig_extrPosPSConfig.fcl"
-#include "mu2e_trig_config/gen/trig_extrPos.fcl"
+# first, trigger filtesr and paths
+#include "mu2e_trig_config/gen/trig_extrPosMenuPSConfig.fcl"
+#include "mu2e_trig_config/gen/trig_extrPosMenu.fcl"
 # then generic digitization
 #include "Production/JobConfig/digitize/Digitize.fcl"
-# set OffSpill timing
-#include "Production/JobConfig/digitize/OffSpill_epilog.fcl"
 # add trigger filters
-physics.filters : { @table::physics.filters @table::Trig_physMenuPSConfig }
+physics.filters : { @table::physics.filters @table::Trig_extrPosMenuPSConfig }
 # add the trigger paths
-physics.trigger_paths : [ @sequence::Digitize.trigger_paths, @sequence::Trig_physMenu.trigger_paths]
+# give paths specific numbers outside trigger path range
+physics.trigger_paths : ["0:DigitizePath", "1:TriggerablePath", @sequence::Trig_extrPosMenu.trigger_paths]
 # configure 'Triggered' output to be calibration triggers
 outputs.TriggeredOutput.SelectEvents : [
   @sequence::Digitize.TrkTriggers,
   @sequence::Digitize.CaloTriggers ]
+outputs.TriggerableOutput.SelectEvents : [ "TriggerablePath" ]
+# set the spill type
+physics.producers.EWMProducer.SpillType : 0
+# Temporarily turn off Crv noise
+physics.producers.CrvSiPMCharges.ThermalRate : 0
+# same for calorimeter
+physics.producers.CaloDigiMaker.addNoise : false
 # no-field
 services.GeometryService.bFieldFile: "Offline/Mu2eG4/geom/bfgeom_no_field.txt"
-physics.filters.TriggerablePrescale.prescaleFactor : 100 # only record 1% of the untriggered
+# allow infinite momemtum
 physics.filters.Triggerable.MaxParticleMom : 1e10
-physics.trigger_paths : [@sequence::Trig_extrPos.trigger_paths]
+physics.filters.TriggerablePrescale.prescaleFactor : 10 # only record 10% of triggerable tracks
 #include "mu2e_trig_config/core/trigDigiInputsEpilog.fcl"

--- a/JobConfig/digitize/OffSpill.fcl
+++ b/JobConfig/digitize/OffSpill.fcl
@@ -2,8 +2,7 @@
 
 # set the spill type
 physics.producers.EWMProducer.SpillType : 0
-# configure 'Triggered' output to be signal
-# FIXME, should match OnSpill?
+# configure 'Triggered' output to include calib triggers
 outputs.TriggeredOutput.SelectEvents : [
   @sequence::Digitize.SignalTriggers,
   @sequence::Digitize.TrkTriggers,
@@ -11,11 +10,12 @@ outputs.TriggeredOutput.SelectEvents : [
 # Lower thresholds for LoopHelix triggerable
 physics.filters.Triggerable.MinParticleMom : 50.0
 physics.filters.Triggerable.MaxParticleMom : 300.0
-
-physics.filters.TriggerableCHEnable.ReturnValue : true # enable high mom triggerable
+physics.trigger_paths : [ "0:DigitizePath", "1:TriggerablePath" , "2:TriggerableCHPath" , @sequence::Trig_physMenu.trigger_paths]
+outputs.TriggerableOutput.SelectEvents : [ "TriggerablePath", "TriggerableCHPath" ]
+physics.filters.TriggerableCHPrescale.prescaleFactor : 10 # only record 10% of triggerable high-momentum tracks
 # Temporarily turn off Crv noise
 physics.producers.CrvSiPMCharges.ThermalRate : 0
 # same for calorimeter
 physics.producers.CaloDigiMaker.addNoise : false
-# turn on MC truth matching for OnSpill triggers run Offline
+# turn on MC truth matching for OnSpill triggers run OffSpill
 #include "Production/JobConfig/digitize/OnSpill_epilog.fcl"

--- a/JobConfig/digitize/OffSpill.fcl
+++ b/JobConfig/digitize/OffSpill.fcl
@@ -8,10 +8,14 @@ outputs.TriggeredOutput.SelectEvents : [
   @sequence::Digitize.SignalTriggers,
   @sequence::Digitize.TrkTriggers,
   @sequence::Digitize.CaloTriggers ]
+# Lower thresholds for LoopHelix triggerable
+physics.filters.Triggerable.MinParticleMom : 50.0
+physics.filters.Triggerable.MaxParticleMom : 300.0
 
-physics.filters.TriggerablePrescale.prescaleFactor : 10 # reduce untriggered
 physics.filters.TriggerableCHEnable.ReturnValue : true # enable high mom triggerable
 # Temporarily turn off Crv noise
 physics.producers.CrvSiPMCharges.ThermalRate : 0
 # same for calorimeter
 physics.producers.CaloDigiMaker.addNoise : false
+# turn on MC truth matching for OnSpill triggers run Offline
+#include "Production/JobConfig/digitize/OnSpill_epilog.fcl"

--- a/JobConfig/digitize/OnSpill.fcl
+++ b/JobConfig/digitize/OnSpill.fcl
@@ -2,7 +2,12 @@
 
 # set the spill type
 physics.producers.EWMProducer.SpillType : 1
+# define paths
+physics.trigger_paths : [ "0:DigitizePath", "1:TriggerablePath" , @sequence::Trig_physMenu.trigger_paths]
 # configure 'Triggered' output to be signal
-physics.filters.TriggerableCHEnable.ReturnValue : false
 outputs.TriggeredOutput.SelectEvents : @local::Digitize.SignalTriggers
+outputs.TriggerableOutput.SelectEvents : [ "TriggerablePath" ]
+# Final configuration
+#include "Production/JobConfig/common/epilog.fcl"
 #include "Production/JobConfig/digitize/OnSpill_epilog.fcl"
+#include "mu2e_trig_config/core/trigDigiInputsEpilog.fcl"

--- a/JobConfig/digitize/OnSpill.fcl
+++ b/JobConfig/digitize/OnSpill.fcl
@@ -3,6 +3,6 @@
 # set the spill type
 physics.producers.EWMProducer.SpillType : 1
 # configure 'Triggered' output to be signal
-# FIXME, should match OffSpill?
+physics.filters.TriggerableCHEnable.ReturnValue : false
 outputs.TriggeredOutput.SelectEvents : @local::Digitize.SignalTriggers
 #include "Production/JobConfig/digitize/OnSpill_epilog.fcl"

--- a/JobConfig/digitize/Spill.fcl
+++ b/JobConfig/digitize/Spill.fcl
@@ -6,5 +6,3 @@
 #include "Production/JobConfig/digitize/Digitize.fcl"
 # add trigger filters
 physics.filters : { @table::physics.filters @table::Trig_physMenuPSConfig }
-# add the trigger paths
-physics.trigger_paths : [ @sequence::Digitize.trigger_paths, @sequence::Trig_physMenu.trigger_paths]

--- a/JobConfig/digitize/epilog.fcl
+++ b/JobConfig/digitize/epilog.fcl
@@ -16,4 +16,5 @@ services.ProditionsService.strawElectronics.useDb: true
 services.ProditionsService.strawElectronics.verbose: 0
 # don't use database time offsets in digitization
 services.ProditionsService.strawElectronics.overrideDbTimeOffsets : true
-
+# temporary fix: this needs to be remove before starting MDC2025 production
+physics.producers.compressDigiMCs.surfaceStepTags : [ "MakeSS" ]

--- a/JobConfig/digitize/prolog.fcl
+++ b/JobConfig/digitize/prolog.fcl
@@ -106,10 +106,6 @@ Digitize: {
       prescaleFactor : 100
       prescaleOffset : 0
     }
-    TriggerableCHEnable : {
-      module_type : FixedFilter
-      # ReturnValue must be set in specific scripts
-    }
     @table::TrigFilters.filters
   }
 
@@ -128,8 +124,7 @@ Digitize: {
 
   TriggerableSequence : [
     TriggerablePrescale, Triggerable ]
-  TriggerableCHSequence : [
-    TriggerableCHEnable, TriggerableCHPrescale, TriggerableCH ]
+  TriggerableCHSequence : [ TriggerableCHPrescale, TriggerableCH ]
 
   TriggerProducts : [
     "keep art::TriggerResults_*_*_*",
@@ -174,7 +169,6 @@ Digitize: {
   #
   TriggerableOutput : {
     module_type : RootOutput
-    SelectEvents : [ "TriggerablePath", "TriggerableCHPath" ] # require events pass 'Triggerable' filter
     fileName    : @nil
   }
   #
@@ -208,8 +202,6 @@ Digitize.Outputs : {
   TriggeredOutput : @local::Digitize.TriggeredOutput
   TriggerableOutput : @local::Digitize.TriggerableOutput
 }
-# give paths specific numbers outside trigger path range
-Digitize.trigger_paths : ["0:DigitizePath", "1:TriggerablePath", "2:TriggerableCHPath" ]
 Digitize.EndPath : [ @sequence::Digitize.EndSequence, TriggeredOutput, TriggerableOutput ]
 # override the trigger digitization sequence
 TrigRecoSequences.artFragmentsGen : @local::Digitize.DigitizeSequence

--- a/JobConfig/digitize/prolog.fcl
+++ b/JobConfig/digitize/prolog.fcl
@@ -103,12 +103,12 @@ Digitize: {
     }
     TriggerableCHPrescale : {
       module_type : Prescaler
-      prescaleFactor : 10
+      prescaleFactor : 100
       prescaleOffset : 0
     }
     TriggerableCHEnable : {
       module_type : FixedFilter
-      ReturnValue : false # by default disable CH triggerable
+      # ReturnValue must be set in specific scripts
     }
     @table::TrigFilters.filters
   }

--- a/JobConfig/mixing/Mix.fcl
+++ b/JobConfig/mixing/Mix.fcl
@@ -18,7 +18,6 @@ physics : {
   # define the digitization paths.  Trigger paths are added specific to digitization type
   DigitizePath : [ @sequence::Mixing.MixSequence ]
   TriggerablePath : [ @sequence::Mixing.MixSequence, @sequence::Digitize.TriggerableSequence ]
-  TriggerableCHPath : [ @sequence::Mixing.MixSequence, @sequence::Digitize.TriggerableCHSequence ]
   # define the trigger sequences and paths
   @table::TrigRecoSequences
   @table::TrigSequences
@@ -30,10 +29,11 @@ physics.end_paths : [ EndPath ]
 # final overrides
 # set the event timing for OnSpill
 physics.producers.EWMProducer.SpillType : 1
-# add the trigger paths
-physics.trigger_paths : [ "0:DigitizePath", "1:TriggerablePath" , "2:TriggerableCHPath", @sequence::Trig_physMenu.trigger_paths]
+# define paths
+physics.trigger_paths : [ "0:DigitizePath", "1:TriggerablePath" , @sequence::Trig_physMenu.trigger_paths]
 # configure 'Triggered' output to be signal
 outputs.TriggeredOutput.SelectEvents : @local::Digitize.SignalTriggers
+outputs.TriggerableOutput.SelectEvents : [ "TriggerablePath" ]
 # Final configuration
 #include "Production/JobConfig/common/epilog.fcl"
 #include "Production/JobConfig/digitize/OnSpill_epilog.fcl"

--- a/Validation/ceDigi.fcl
+++ b/Validation/ceDigi.fcl
@@ -1,5 +1,7 @@
 #include "Production/JobConfig/digitize/OnSpill.fcl"
 physics.producers.MakeSS : { module_type : NullProducer }
+# temporary fix: this won't be needed after starting MDC2025 production
+physics.producers.compressDigiMCs.surfaceStepTags : [ "compressDetStepMCs" ]
 
 services.scheduler.wantSummary: true
 services.TimeTracker.printSummary: true

--- a/Validation/ceMix.fcl
+++ b/Validation/ceMix.fcl
@@ -3,6 +3,9 @@
 #
 #include "Production/JobConfig/mixing/Mix.fcl"
 physics.producers.MakeSS : { module_type : NullProducer }
+# temporary fix: this won't be needed after starting MDC2025 production
+physics.producers.compressDigiMCs.surfaceStepTags : [ "compressDetStepMCs" ]
+# complete the mixing config
 services.SeedService.baseSeed         :  8
 source.fileNames : [ "dts.owner.ceSteps.dsconf.seq.art" ]
 physics.filters.MuStopPileupMixer.mu2e.simStageEfficiencyTags: []

--- a/Validation/cosmicOffSpill.fcl
+++ b/Validation/cosmicOffSpill.fcl
@@ -10,7 +10,3 @@ source.fileNames : [
 outputs.TriggeredOutput.fileName : "dig.owner.cosmicOffSpill.seq.art"
 outputs.TriggerableOutput.fileName : "/dev/null"
 #include "Production/Validation/database.fcl"
-#
-# temporary patch for processing MDC2020 data
-#
-#include "Production/JobConfig/digitize/MakeSurfaceSteps.fcl"


### PR DESCRIPTION
Small fixes and optimizations for digitizing OffSpill. This now includes MC truth matching for the physics triggers, and lowers the threshold for Triggerable. This will produce substantially more output as the CentralHelix trigger prescale has been set to 1 (formerly 100).