### PR TITLE
Remove extra Mu2eKinKal prolog include

### DIFF
--- a/Validation/reco.fcl
+++ b/Validation/reco.fcl
@@ -1,7 +1,6 @@
 #
 # run tracker and cal reco from a file of digis
 #
-#include "Offline/Mu2eKinKal/fcl/prolog.fcl"
 #include "Production/JobConfig/reco/Reco.fcl"
 # add KinKal fits
 #


### PR DESCRIPTION
Remove an extra Mu2eKinKal prolog include line from the Validation reco fcl, as this throws an error as Offline/TrkPatRec/fcl/Particle.fcl is not yet included. This prolog is already included in JobConfig/reco/Reco.fcl so it is not needed here.