### PR TITLE
Lower photon conversion filtering to match photon generation

### DIFF
--- a/JobConfig/primary/RMCFlatGammaResampling.fcl
+++ b/JobConfig/primary/RMCFlatGammaResampling.fcl
@@ -5,3 +5,8 @@
 #include "Production/JobConfig/primary/RMCGammaResampling.fcl"
 outputs.PrimaryOutput.fileName : "dts.owner.RMCFlatGammaConversions.version.sequencer.art"
 physics.producers.FindMCPrimary.PrimaryProcess : "mu2eFlatPhoton"
+
+# Filter low energy conversions out
+physics.filters.GenFilter.filterEnergy : true
+physics.filters.GenFilter.emin : 78.
+physics.filters.GenFilter.emax : 1000.


### PR DESCRIPTION
The RMC flat gamma conversion sample was generated with E in [80,102] MeV, so I'm lowering the gen-filter cut to 78 MeV to more closely match this. 