### PR TITLE
Change default config to be processing dts with SurfaceSteps

### DIFF
--- a/JobConfig/digitize/MakeSurfaceSteps.fcl
+++ b/JobConfig/digitize/MakeSurfaceSteps.fcl
@@ -2,4 +2,11 @@
 # This script is a patch to allow digitizing existing MDC2020 dts files, which do not have SurfaceSteps in them.
 # it should be sourced as epilog after digitization
 #
+physics.producers.MakeSS : {
+  @table::CommonMC.MakeSS
+  VDStepPointMCs : "compressDetStepMCs:virtualdetector"
+  AbsorberStepPointMCs : "compressDetStepMCs:protonabsorber"
+  TargetStepPointMCs : "compressDetStepMCs:stoppingtarget"
+}
+physics.DigitizePath : [ "MakeSS" , @sequence::physics.DigitizePath ]
 physics.producers.compressDigiMCs.surfaceStepTags : [ "MakeSS" ]

--- a/JobConfig/digitize/MakeSurfaceSteps.fcl
+++ b/JobConfig/digitize/MakeSurfaceSteps.fcl
@@ -8,5 +8,4 @@ physics.producers.MakeSS : {
   AbsorberStepPointMCs : "compressDetStepMCs:protonabsorber"
   TargetStepPointMCs : "compressDetStepMCs:stoppingtarget"
 }
-physics.DigitizePath : [ "MakeSS" , @sequence::physics.DigitizePath ]
 physics.producers.compressDigiMCs.surfaceStepTags : [ "MakeSS" ]

--- a/JobConfig/digitize/epilog.fcl
+++ b/JobConfig/digitize/epilog.fcl
@@ -16,7 +16,3 @@ services.ProditionsService.strawElectronics.useDb: true
 services.ProditionsService.strawElectronics.verbose: 0
 # don't use database time offsets in digitization
 services.ProditionsService.strawElectronics.overrideDbTimeOffsets : true
-# not all digis in MDC2020 include SurfaceSteps. If processing a sample without those,
-# uncomment the first line and comment the 2nd
-#physics.producers.compressDigiMCs.surfaceStepTags : [ "MakeSS" ]
-physics.producers.MakeSS : { module_type : NullProducer }

--- a/JobConfig/digitize/epilog.fcl
+++ b/JobConfig/digitize/epilog.fcl
@@ -16,5 +16,7 @@ services.ProditionsService.strawElectronics.useDb: true
 services.ProditionsService.strawElectronics.verbose: 0
 # don't use database time offsets in digitization
 services.ProditionsService.strawElectronics.overrideDbTimeOffsets : true
-# temporary fix: this needs to be remove before starting MDC2025 production
-physics.producers.compressDigiMCs.surfaceStepTags : [ "MakeSS" ]
+# not all digis in MDC2020 include SurfaceSteps. If processing a sample without those,
+# uncomment the first line and comment the 2nd
+#physics.producers.compressDigiMCs.surfaceStepTags : [ "MakeSS" ]
+physics.producers.MakeSS : { module_type : NullProducer }

--- a/JobConfig/digitize/prolog.fcl
+++ b/JobConfig/digitize/prolog.fcl
@@ -50,6 +50,7 @@ Digitize: {
       mean : 1
       halfWidth : 0
     }
+    MakeSS : { module_type : NullProducer } # temporary patch for older MDC2020 output
 # Trigger MC matching instances for each helix algorithm
     TTAprKSFMC : {
       @table::CommonMC.TTSelectRecoMC
@@ -109,6 +110,7 @@ Digitize: {
 
   DigitizeSequence : [
     PBISim,
+    MakeSS,
     @sequence::CommonMC.DigiSim,
     @sequence::TrackerMC.DigiSim,
     @sequence::CaloMC.DigiSim,

--- a/JobConfig/digitize/prolog.fcl
+++ b/JobConfig/digitize/prolog.fcl
@@ -67,12 +67,6 @@ Digitize: {
       @table::CommonMC.TTSelectRecoMC
       KalSeedCollections  : [ "TTCalSeedFitDe" ]
     }
-    MakeSS : {
-      @table::CommonMC.MakeSS
-      VDStepPointMCs : "compressDetStepMCs:virtualdetector"
-      AbsorberStepPointMCs : "compressDetStepMCs:protonabsorber"
-      TargetStepPointMCs : "compressDetStepMCs:stoppingtarget"
-    }
   }
   filters : {
 # filter for Triggerable stream.  These should be events that might have
@@ -119,7 +113,6 @@ Digitize: {
     @sequence::TrackerMC.DigiSim,
     @sequence::CaloMC.DigiSim,
     @sequence::CrvDAQPackage.CrvDAQSequence,
-    MakeSS,
     compressDigiMCs ]
 
   TriggerableSequence : [

--- a/JobConfig/primary/AddSurfaceSteps.fcl
+++ b/JobConfig/primary/AddSurfaceSteps.fcl
@@ -1,0 +1,35 @@
+#
+# This script is a patch to create SurfaceSteps in primary dts files created without them
+#
+#include "Offline/fcl/standardServices.fcl"
+#include "Offline/CommonMC/fcl/prolog.fcl"
+process_name: AddSS
+source: { module_type : RootInput }
+services : @local::Services.Reco
+outputs : {
+  CopyOutput : {
+    module_type: RootOutput
+    outputCommands : [ "keep *_*_*_*",
+    "drop  mu2e::StepPointMCs_*_protonabsorber_*",
+    "drop  mu2e::StepPointMCs_*_stoppingtarget_*" ]
+    fileName : "dts.mu2e.AddSurfaceSteps.Test.0.art"
+  }
+}
+
+physics : {
+  producers : {
+    # the following name is a hack to make the provenance of the SurfaceSteps correct
+    compressDetStepMCs : {
+      @table::CommonMC.MakeSS
+      VDStepPointMCs : "compressDetStepMCs:virtualdetector"
+      AbsorberStepPointMCs : "compressDetStepMCs:protonabsorber"
+      TargetStepPointMCs : "compressDetStepMCs:stoppingtarget"
+    }
+  }
+  AddSSPath : [ "compressDetStepMCs" ]
+  trigger_paths : [ "AddSSPath" ]
+  CopyPath : [ "CopyOutput" ]
+  end_paths : [ "CopyPath" ]
+}
+
+

--- a/Validation/ceSimReco.fcl
+++ b/Validation/ceSimReco.fcl
@@ -105,9 +105,12 @@ outputs : {
   }
 }
 # fix MakeSS config (overwritten by digi, reco)
-physics.producers.MakeSS.VDStepPointMCs : "g4run:virtualdetector"
-physics.producers.MakeSS.AbsorberStepPointMCs : "g4run:protonabsorber"
-physics.producers.MakeSS.TargetStepPointMCs : "g4run:stoppingtarget"
+physics.producers.MakeSS : {
+  @table::CommonMC.MakeSS
+  VDStepPointMCs : "g4run:virtualdetector"
+  AbsorberStepPointMCs : "g4run:protonabsorber"
+  TargetStepPointMCs : "g4run:stoppingtarget"
+}
 
 #include "Production/JobConfig/primary/epilog.fcl"
 #include "Production/JobConfig/digitize/epilog.fcl"

--- a/Validation/cosmicOffSpill.fcl
+++ b/Validation/cosmicOffSpill.fcl
@@ -1,4 +1,5 @@
 #include "Production/JobConfig/digitize/OffSpill.fcl"
+#include "Production/JobConfig/digitize/MakeSurfaceSteps.fcl"
 
 services.scheduler.wantSummary: true
 services.SeedService.baseSeed: 8

--- a/Validation/cosmicSimReco.fcl
+++ b/Validation/cosmicSimReco.fcl
@@ -94,9 +94,12 @@ outputs : {
   }
 }
 # fix MakeSS config (overwritten by digi, reco)
-physics.producers.MakeSS.VDStepPointMCs : "g4run:virtualdetector"
-physics.producers.MakeSS.AbsorberStepPointMCs : "g4run:protonabsorber"
-physics.producers.MakeSS.TargetStepPointMCs : "g4run:stoppingtarget"
+physics.producers.MakeSS : {
+  @table::CommonMC.MakeSS
+  VDStepPointMCs : "g4run:virtualdetector"
+  AbsorberStepPointMCs : "g4run:protonabsorber"
+  TargetStepPointMCs : "g4run:stoppingtarget"
+}
 
 #include "Production/JobConfig/primary/epilog.fcl"
 #include "Production/JobConfig/digitize/epilog.fcl"


### PR DESCRIPTION
This PR modifies the digitization script to be compatible with primaries produced after MDC2020ap, where SurfaceSteps replaced StepPointMCs for passive materials. It also adds a script to patch primaries produced prior to that.