### PR TITLE
renaming daq decoders processing module

### DIFF
--- a/JobConfig/digitize/prolog.fcl
+++ b/JobConfig/digitize/prolog.fcl
@@ -199,7 +199,7 @@ Digitize.Outputs : {
 }
 Digitize.EndPath : [ @sequence::Digitize.EndSequence, TriggeredOutput, TriggerableOutput ]
 # override the trigger digitization sequence
-TrigRecoSequences.artFragmentsGen : @local::Digitize.DigitizeSequence
+TrigRecoSequences.dtcAndCFOEventsGen : @local::Digitize.DigitizeSequence
 END_PROLOG
 # Trigger Sequences have to come after
 #include "mu2e-trig-config/core/trigSequences.fcl"

--- a/JobConfig/digitize/trigSequencesMC.fcl
+++ b/JobConfig/digitize/trigSequencesMC.fcl
@@ -3,6 +3,6 @@
 BEGIN_PROLOG
 TrigRecoSequences:{
    @table::TrigRecoSequences
-   artFragmentsGen    : [ @sequence::Digitize.DigitizeSequence ]
+   dtcAndCFOEventsGen    : [ @sequence::Digitize.DigitizeSequence ]
 }
 END_PROLOG

--- a/JobConfig/mixing/Mix.fcl
+++ b/JobConfig/mixing/Mix.fcl
@@ -4,7 +4,7 @@
 #include "Production/JobConfig/common/prolog.fcl"
 #include "Production/JobConfig/digitize/prolog.fcl"
 #include "Production/JobConfig/mixing/prolog.fcl"
-# the following MUST come after mixing, as that overrides artFragmentsGen sequence
+# the following MUST come after mixing, as that overrides dtcAndCFOEventsGen sequence
 #include "mu2e-trig-config/core/trigSequences.fcl"
 #include "mu2e-trig-config/gen/trig_physMenuPSConfig.fcl"
 #include "mu2e-trig-config/gen/trig_physMenu.fcl"

--- a/JobConfig/mixing/MixTrigVal.fcl
+++ b/JobConfig/mixing/MixTrigVal.fcl
@@ -4,7 +4,7 @@
 #include "Production/JobConfig/common/prolog.fcl"
 #include "Production/JobConfig/digitize/prolog.fcl"
 #include "Production/JobConfig/mixing/prolog.fcl"
-# the following MUST come after mixing, as that overrides artFragmentsGen sequence
+# the following MUST come after mixing, as that overrides dtcAndCFOEventsGen sequence
 #include "mu2e-trig-config/core/trigSequences.fcl"
 #include "mu2e-trig-config/gen/trig_valMenuPSConfig_OnSpill.fcl"
 #include "mu2e-trig-config/gen/trig_valMenu_OnSpill.fcl"

--- a/JobConfig/mixing/prolog.fcl
+++ b/JobConfig/mixing/prolog.fcl
@@ -84,7 +84,7 @@ Mixing : {
 Mixing.PileupMixSequence : [ PBISim, @sequence::Mixing.StepMixSequence, @sequence::Mixing.StepFilterSequence ]
 Mixing.MixSequence : [ @sequence::Mixing.PileupMixSequence, @sequence::Digitize.DigitizeSequence ]
 # override the Trigger 'PrepareDigis' sequence; the mixers must preceed the digi making
-TrigRecoSequences.artFragmentsGen: [ @sequence::Mixing.PileupMixSequence, @sequence::Digitize.DigitizeSequence ]
+TrigRecoSequences.dtcAndCFOEventsGen: [ @sequence::Mixing.PileupMixSequence, @sequence::Digitize.DigitizeSequence ]
 #
 # The following is used to guarantee consistency when filtering pileup when mixing a primary that could also be part of pileup
 #


### PR DESCRIPTION
simple renaming of DAQ module instances according to https://github.com/Mu2e/Offline/pull/1434