### PR TITLE
Increase MC filtering threshold on external RMC generation

### DIFF
--- a/JobConfig/primary/RMCExternal.fcl
+++ b/JobConfig/primary/RMCExternal.fcl
@@ -4,6 +4,7 @@
 
 #include "Production/JobConfig/primary/RMC.fcl"
 
+physics.filters.PrimaryFilter.MinimumPartMom : 80.
 physics.producers.generate.decayProducts.mode : "external"
 physics.producers.FindMCPrimary.PrimaryProcess : "mu2eExternalRMC"
 outputs.PrimaryOutput.fileName : "dts.owner.RMCExternal.version.sequencer.art"


### PR DESCRIPTION
Increase the MC filtering in the RMC external simulation to more closely match the generation energy threshold. As the photon energy range only goes down to 85 MeV, the electron/positron spectrum shape below this becomes unphysical due to the missing photons below 85 MeV. For an 80 MeV/c primary filter threshold, I found 12 events in a 100k simulation passed the primary particle filtering (~0.01-0.02%). For a 3 billion RMC photon generation (around the Run 1 expectation) this would lead to about 60k accepted events overall.