### PR TITLE
Rename low p multi-trk --> high p multi trk due to high threshold used

### DIFF
--- a/JobConfig/digitize/OnSpill_epilog.fcl
+++ b/JobConfig/digitize/OnSpill_epilog.fcl
@@ -9,7 +9,7 @@ physics.producers.TTmakePH.StrawHitMask          : @local::TrkHitReco.makePH.Str
 physics.apr_highP : [@sequence::physics.apr_highP, TTAprKSFMC ]
 physics.apr_highP_stopTarg : [@sequence::physics.apr_highP_stopTarg, TTAprKSFMC ]
 physics.apr_lowP_stopTarg : [@sequence::physics.apr_lowP_stopTarg, TTAprKSFMC ]
-physics.apr_lowP_stopTarg_multiTrk : [@sequence::physics.apr_lowP_stopTarg_multiTrk, TTAprKSFMC ]
+physics.apr_highP_stopTarg_multiTrk : [@sequence::physics.apr_highP_stopTarg_multiTrk, TTAprKSFMC ]
 # tpr
 physics.tprDe_highP : [@sequence::physics.tprDe_highP, TTTprDeKSFMC ]
 physics.tprDe_highP_stopTarg : [@sequence::physics.tprDe_highP_stopTarg, TTTprDeKSFMC ]


### PR DESCRIPTION
We renamed the `apr_lowP_stopTarg_multiTrk` trigger path to use `highP` in the name, as the path uses an 80 MeV/c threshold on both tracks (which corresponds to the `highP` trigger).