### PR TITLE
Add production scripts for physical RPC spectra

### DIFF
--- a/JobConfig/primary/RPC.fcl
+++ b/JobConfig/primary/RPC.fcl
@@ -14,7 +14,7 @@ physics.producers.generate : {
   spectrum : {
     spectrumShape : Bistirlich
     elow : 50.0 #MeV
-    ehi : 139.5.
+    ehi : 139.5
     spectrumResolution : 0.1 #MeV
   }
   pionDecayOff : true # will apply surv prob

--- a/JobConfig/primary/RPCExternalPhysical.fcl
+++ b/JobConfig/primary/RPCExternalPhysical.fcl
@@ -1,0 +1,9 @@
+#
+# RPC External, physical pion time distribution
+#
+
+#include "Production/JobConfig/primary/RPCPhysical.fcl"
+
+physics.producers.generate.RPCType : "mu2eExternalRPC"
+physics.producers.FindMCPrimary.PrimaryProcess : "mu2eExternalRPC"
+outputs.PrimaryOutput.fileName: "dts.owner.RPCExternalPhysical.version.sequencer.art"

--- a/JobConfig/primary/RPCInternalPhysical.fcl
+++ b/JobConfig/primary/RPCInternalPhysical.fcl
@@ -1,0 +1,9 @@
+#
+# RPC Internal, physical pion time distribution
+#
+
+#include "Production/JobConfig/primary/RPCPhysical.fcl"
+
+physics.producers.generate.RPCType : "mu2eInternalRPC"
+physics.producers.FindMCPrimary.PrimaryProcess : "mu2eInternalRPC"
+outputs.PrimaryOutput.fileName: "dts.owner.RPCInternalPhysical.version.sequencer.art"

--- a/JobConfig/primary/RPCPhysical.fcl
+++ b/JobConfig/primary/RPCPhysical.fcl
@@ -1,0 +1,15 @@
+##
+# RPC photon spectrum, based on on Bistrilich spectrum
+# Use accept-reject method to produce a physical pion time distribution
+#
+
+#include "Production/JobConfig/primary/RPC.fcl"
+
+physics.producers.RPCAcceptReject : @erase
+physics.filters.RPCAcceptReject : {
+    module_type : WeightSamplingFilter
+    EventWeightModule   : generate
+    WeightScalingFactor : 10000. # Maximum time weight is e^-0 = 1, but (essentially) all RPC events have p(evt) < 1e-4, so increase sampling efficiency
+    debugLevel          : 1
+    makeHistograms      : true
+}

--- a/JobConfig/primary/TargetPiStopParticle.fcl
+++ b/JobConfig/primary/TargetPiStopParticle.fcl
@@ -5,7 +5,12 @@
 # edited for pions by : Sophie Middleton
 #include "Production/JobConfig/primary/StopParticle.fcl"
 
-physics.PrimaryPath : [ TargetPiStopResampler, @sequence::Common.generateSequence, @sequence::Common.g4Sequence, @sequence::Primary.PrimarySequence ]
+# Only filter if creating a physical spectrum
+physics.producers.RPCAcceptReject : {
+    module_type : NullProducer
+    nEngines : 1
+}
+physics.PrimaryPath : [ TargetPiStopResampler, @sequence::Common.generateSequence, RPCAcceptReject, @sequence::Common.g4Sequence, @sequence::Primary.PrimarySequence ]
 physics.trigger_paths : [ PrimaryPath ]
 outputs : { PrimaryOutput : @local::Primary.PrimaryOutput }
 physics.EndPath : [ @sequence::Primary.EndSequence, PrimaryOutput ]


### PR DESCRIPTION
Generate physical RPC spectra from infinite pion lifetime samples for use in MDS campaigns. This is in connection with https://github.com/Mu2e/Offline/pull/1479