### PR TITLE
Update accept/reject filter configuration

### DIFF
--- a/JobConfig/primary/RPCPhysical.fcl
+++ b/JobConfig/primary/RPCPhysical.fcl
@@ -8,8 +8,8 @@
 physics.producers.RPCAcceptReject : @erase
 physics.filters.RPCAcceptReject : {
     module_type : WeightSamplingFilter
-    EventWeightModule   : generate
-    WeightScalingFactor : 10000. # Maximum time weight is e^-0 = 1, but (essentially) all RPC events have p(evt) < 1e-4, so increase sampling efficiency
+    inputTag            : generate
+    maximumWeight       : 1e-4 # Maximum time weight theoretically is e^-0 = 1, but (essentially) all RPC events have p(evt) < 1e-4, so increase sampling efficiency
     debugLevel          : 1
     makeHistograms      : true
 }


### PR DESCRIPTION
The accept/reject filter module used in the physical RPC productions was updated in PR https://github.com/Mu2e/Offline/pull/1483. This updates the configuration parameters, without changing the simulation results.