### PR TITLE
Add a triggerable selection for two track events

### DIFF
--- a/JobConfig/digitize/DTSfilter.fcl
+++ b/JobConfig/digitize/DTSfilter.fcl
@@ -9,7 +9,7 @@
 # name all processes the same, to mask any provenance in ensemble creation
 process_name: DTSFilter
 source : { module_type : RootInput }
-services : @local::Services.SimAndReco 
+services : @local::Services.SimAndReco
 physics : {
   producers : {
     @table::Digitize.producers
@@ -17,14 +17,14 @@ physics : {
   }
   filters: {
     @table::Digitize.filters
-    @table::TrigFilters.filters   
+    @table::TrigFilters.filters
     @table::Trig_physMenuPSConfig
   }
   analyzers: { @table::Digitize.analyzers }
   # define the digitization paths.  Trigger paths are added specific to digitization type
   DigitizePath : @local::Digitize.DigitizeSequence
 }
-#physics.filters.Triggerable.MinNDigis : 13
+#physics.filters.TriggerableLH.MinNDigis : 13
 physics.trigger_paths : [@sequence::Trig_physMenu.trigger_paths]
 
 physics.trigger_paths[0] : DigitizePath

--- a/JobConfig/digitize/Digitize.fcl
+++ b/JobConfig/digitize/Digitize.fcl
@@ -14,7 +14,7 @@ physics : {
   analyzers: { @table::Digitize.analyzers }
   # define the digitization paths.  Trigger paths are added specific to digitization type
   DigitizePath : @local::Digitize.DigitizeSequence
-  TriggerablePath : [ @sequence::Digitize.DigitizeSequence, @sequence::Digitize.TriggerableSequence ]
+  TriggerableLHPath : [ @sequence::Digitize.DigitizeSequence, @sequence::Digitize.TriggerableLHSequence ]
   TriggerableCHPath : [ @sequence::Digitize.DigitizeSequence, @sequence::Digitize.TriggerableCHSequence ]
   TriggerableTwoTrackPath : [ @sequence::Digitize.DigitizeSequence, @sequence::Digitize.TriggerableTwoTrackSequence ]
   # define the trigger sequences and paths

--- a/JobConfig/digitize/Digitize.fcl
+++ b/JobConfig/digitize/Digitize.fcl
@@ -16,6 +16,7 @@ physics : {
   DigitizePath : @local::Digitize.DigitizeSequence
   TriggerablePath : [ @sequence::Digitize.DigitizeSequence, @sequence::Digitize.TriggerableSequence ]
   TriggerableCHPath : [ @sequence::Digitize.DigitizeSequence, @sequence::Digitize.TriggerableCHSequence ]
+  TriggerableTwoTrackPath : [ @sequence::Digitize.DigitizeSequence, @sequence::Digitize.TriggerableTwoTrackSequence ]
   # define the trigger sequences and paths
   @table::TrigRecoSequences
   @table::TrigSequences

--- a/JobConfig/digitize/NoField.fcl
+++ b/JobConfig/digitize/NoField.fcl
@@ -6,14 +6,15 @@
 #include "Production/JobConfig/digitize/Digitize.fcl"
 # add trigger filters
 physics.filters : { @table::physics.filters @table::Trig_extrPosMenuPSConfig }
+# Define the default list of triggerable paths
+physics.TriggerablePaths : [ "TriggerableLHPath" ]
 # add the trigger paths
-# give paths specific numbers outside trigger path range
-physics.trigger_paths : ["0:DigitizePath", "1:TriggerablePath", @sequence::Trig_extrPosMenu.trigger_paths]
+physics.trigger_paths : ["DigitizePath", @sequence::physics.TriggerablePaths, @sequence::Trig_extrPosMenu.trigger_paths]
 # configure 'Triggered' output to be calibration triggers
 outputs.TriggeredOutput.SelectEvents : [
   @sequence::Digitize.TrkTriggers,
   @sequence::Digitize.CaloTriggers ]
-outputs.TriggerableOutput.SelectEvents : [ "TriggerablePath" ]
+outputs.TriggerableOutput.SelectEvents : [ @sequence::physics.TriggerablePaths ]
 # set the spill type
 physics.producers.EWMProducer.SpillType : 0
 # Temporarily turn off Crv noise
@@ -23,6 +24,6 @@ physics.producers.CaloDigiMaker.addNoise : false
 # no-field
 services.GeometryService.bFieldFile: "Offline/Mu2eG4/geom/bfgeom_no_field.txt"
 # allow infinite momemtum
-physics.filters.Triggerable.MaxParticleMom : 1e10
-physics.filters.TriggerablePrescale.prescaleFactor : 10 # only record 10% of triggerable tracks
+physics.filters.TriggerableLH.MaxParticleMom : 1e10
+physics.filters.TriggerableLHPrescale.prescaleFactor : 10 # only record 10% of triggerable tracks
 #include "mu2e-trig-config/core/trigDigiInputsEpilog.fcl"

--- a/JobConfig/digitize/OffSpill.fcl
+++ b/JobConfig/digitize/OffSpill.fcl
@@ -8,12 +8,12 @@ outputs.TriggeredOutput.SelectEvents : [
   @sequence::Digitize.TrkTriggers,
   @sequence::Digitize.CaloTriggers ]
 # Lower thresholds for LoopHelix triggerable
-physics.filters.Triggerable.MinParticleMom : 50.0
-physics.filters.Triggerable.MaxParticleMom : 300.0
+physics.filters.TriggerableLH.MinParticleMom : 50.0
+physics.filters.TriggerableLH.MaxParticleMom : 300.0
 # Define the default list of triggerable paths
-physics.TriggerablePaths : [ "TriggerablePath", "TriggerableCHPath"]
+physics.TriggerablePaths : [ "TriggerableLHPath", "TriggerableCHPath"]
 # Define the trigger path
-physics.trigger_paths : [ "0:DigitizePath", @sequence::physics.TriggerablePaths,  @sequence::Trig_physMenu.trigger_paths]
+physics.trigger_paths : [ "DigitizePath", @sequence::physics.TriggerablePaths,  @sequence::Trig_physMenu.trigger_paths]
 outputs.TriggerableOutput.SelectEvents : [ @sequence::physics.TriggerablePaths ]
 physics.filters.TriggerableCHPrescale.prescaleFactor : 10 # only record 10% of triggerable high-momentum tracks
 # Temporarily turn off Crv noise

--- a/JobConfig/digitize/OffSpill.fcl
+++ b/JobConfig/digitize/OffSpill.fcl
@@ -10,8 +10,11 @@ outputs.TriggeredOutput.SelectEvents : [
 # Lower thresholds for LoopHelix triggerable
 physics.filters.Triggerable.MinParticleMom : 50.0
 physics.filters.Triggerable.MaxParticleMom : 300.0
-physics.trigger_paths : [ "0:DigitizePath", "1:TriggerablePath" , "2:TriggerableCHPath" , @sequence::Trig_physMenu.trigger_paths]
-outputs.TriggerableOutput.SelectEvents : [ "TriggerablePath", "TriggerableCHPath" ]
+# Define the default list of triggerable paths
+physics.TriggerablePaths : [ "TriggerablePath", "TriggerableCHPath"]
+# Define the trigger path
+physics.trigger_paths : [ "0:DigitizePath", @sequence::physics.TriggerablePaths,  @sequence::Trig_physMenu.trigger_paths]
+outputs.TriggerableOutput.SelectEvents : [ @sequence::physics.TriggerablePaths ]
 physics.filters.TriggerableCHPrescale.prescaleFactor : 10 # only record 10% of triggerable high-momentum tracks
 # Temporarily turn off Crv noise
 physics.producers.CrvSiPMCharges.ThermalRate : 0

--- a/JobConfig/digitize/OnSpill.fcl
+++ b/JobConfig/digitize/OnSpill.fcl
@@ -3,10 +3,10 @@
 # set the spill type
 physics.producers.EWMProducer.SpillType : 1
 # define paths
-physics.trigger_paths : [ "0:DigitizePath", "1:TriggerablePath" , @sequence::Trig_physMenu.trigger_paths]
+physics.trigger_paths : [ "0:DigitizePath", "1:TriggerablePath", "3:TriggerableTwoTrackPath",  @sequence::Trig_physMenu.trigger_paths]
 # configure 'Triggered' output to be signal
 outputs.TriggeredOutput.SelectEvents : @local::Digitize.SignalTriggers
-outputs.TriggerableOutput.SelectEvents : [ "TriggerablePath" ]
+outputs.TriggerableOutput.SelectEvents : [ "TriggerablePath", "TriggerableTwoTrackPath" ]
 # Final configuration
 #include "Production/JobConfig/common/epilog.fcl"
 #include "Production/JobConfig/digitize/OnSpill_epilog.fcl"

--- a/JobConfig/digitize/OnSpill.fcl
+++ b/JobConfig/digitize/OnSpill.fcl
@@ -2,11 +2,13 @@
 
 # set the spill type
 physics.producers.EWMProducer.SpillType : 1
-# define paths
-physics.trigger_paths : [ "0:DigitizePath", "1:TriggerablePath", "3:TriggerableTwoTrackPath",  @sequence::Trig_physMenu.trigger_paths]
+# Define the default list of triggerable paths
+physics.TriggerablePaths : [ "TriggerablePath", "TriggerableTwoTrackPath"]
+# Define the trigger path
+physics.trigger_paths : [ "0:DigitizePath", @sequence::physics.TriggerablePaths,  @sequence::Trig_physMenu.trigger_paths]
 # configure 'Triggered' output to be signal
 outputs.TriggeredOutput.SelectEvents : @local::Digitize.SignalTriggers
-outputs.TriggerableOutput.SelectEvents : [ "TriggerablePath", "TriggerableTwoTrackPath" ]
+outputs.TriggerableOutput.SelectEvents : [ @sequence::physics.TriggerablePaths ]
 # Final configuration
 #include "Production/JobConfig/common/epilog.fcl"
 #include "Production/JobConfig/digitize/OnSpill_epilog.fcl"

--- a/JobConfig/digitize/OnSpill.fcl
+++ b/JobConfig/digitize/OnSpill.fcl
@@ -3,9 +3,9 @@
 # set the spill type
 physics.producers.EWMProducer.SpillType : 1
 # Define the default list of triggerable paths
-physics.TriggerablePaths : [ "TriggerablePath", "TriggerableTwoTrackPath"]
+physics.TriggerablePaths : [ "TriggerableLHPath", "TriggerableTwoTrackPath"]
 # Define the trigger path
-physics.trigger_paths : [ "0:DigitizePath", @sequence::physics.TriggerablePaths,  @sequence::Trig_physMenu.trigger_paths]
+physics.trigger_paths : [ "DigitizePath", @sequence::physics.TriggerablePaths,  @sequence::Trig_physMenu.trigger_paths]
 # configure 'Triggered' output to be signal
 outputs.TriggeredOutput.SelectEvents : @local::Digitize.SignalTriggers
 outputs.TriggerableOutput.SelectEvents : [ @sequence::physics.TriggerablePaths ]

--- a/JobConfig/digitize/OnSpill2Trk.fcl
+++ b/JobConfig/digitize/OnSpill2Trk.fcl
@@ -1,0 +1,5 @@
+# Configure digitization with a triggerable filter for two track events
+#include "Production/JobConfig/digitize/OnSpill.fcl"
+
+# Turn on the MC selection for two track events
+physics.filters.TriggerableTwoTrackPrescale.prescaleOffset : 0

--- a/JobConfig/digitize/prolog.fcl
+++ b/JobConfig/digitize/prolog.fcl
@@ -101,6 +101,21 @@ Digitize: {
       prescaleFactor : 100
       prescaleOffset : 0
     }
+    TriggerableTwoTrack : {
+      module_type : StrawDigiMCFilter
+      MinNParticles : 2
+      MinNDigis : 15
+      MinParticleMom : 30.0
+      MaxParticleMom : 300.0 # nominally particles that can form Loophelices in the tracker
+      StrawDigiMCCollection : compressDigiMCs
+      particleTypes : [ 11,-11, 13, -13, 211, -211] # e+-, mu+-, pi+-
+    }
+    # Triggerable stream prescaler; stream-dependent
+    TriggerableTwoTrackPrescale : {
+      module_type : Prescaler
+      prescaleFactor : 1 # by default, prescale all events (n % 1 != 1 for all n)
+      prescaleOffset : 1
+    }
     @table::TrigFilters.filters
   }
 
@@ -120,6 +135,7 @@ Digitize: {
   TriggerableSequence : [
     TriggerablePrescale, Triggerable ]
   TriggerableCHSequence : [ TriggerableCHPrescale, TriggerableCH ]
+  TriggerableTwoTrackSequence : [ TriggerableTwoTrackPrescale, TriggerableTwoTrack ]
 
   TriggerProducts : [
     "keep art::TriggerResults_*_*_*",

--- a/JobConfig/digitize/prolog.fcl
+++ b/JobConfig/digitize/prolog.fcl
@@ -74,7 +74,7 @@ Digitize: {
 # triggered.  The default setting is a particle with enough tracker digis
     # in the right momentum range to be reconstructable as a helix
     # This filter should be overriden as needed for other kinds of primaries (straight cosmics, calo signals, ...)
-    Triggerable : {
+    TriggerableLH : {
       module_type : StrawDigiMCFilter
       MinNDigis : 15
       MinParticleMom : 75.0
@@ -83,7 +83,7 @@ Digitize: {
       particleTypes : [ 11,-11, 13, -13, 211, -211] # e+-, mu+-, pi+-
     }
     # Triggerable stream prescaler; stream-dependent
-    TriggerablePrescale : {
+    TriggerableLHPrescale : {
       module_type : Prescaler
       prescaleFactor : 1 # by default, don't prescale
       prescaleOffset : 0
@@ -132,8 +132,7 @@ Digitize: {
     @sequence::CrvDAQPackage.CrvDAQSequence,
     compressDigiMCs ]
 
-  TriggerableSequence : [
-    TriggerablePrescale, Triggerable ]
+  TriggerableLHSequence : [ TriggerableLHPrescale, TriggerableLH ]
   TriggerableCHSequence : [ TriggerableCHPrescale, TriggerableCH ]
   TriggerableTwoTrackSequence : [ TriggerableTwoTrackPrescale, TriggerableTwoTrack ]
 

--- a/JobConfig/mixing/Mix.fcl
+++ b/JobConfig/mixing/Mix.fcl
@@ -18,6 +18,7 @@ physics : {
   # define the digitization paths.  Trigger paths are added specific to digitization type
   DigitizePath : [ @sequence::Mixing.MixSequence ]
   TriggerablePath : [ @sequence::Mixing.MixSequence, @sequence::Digitize.TriggerableSequence ]
+  TriggerableTwoTrackPath : [ @sequence::Digitize.DigitizeSequence, @sequence::Digitize.TriggerableTwoTrackSequence ]
   # define the trigger sequences and paths
   @table::TrigRecoSequences
   @table::TrigSequences
@@ -30,13 +31,12 @@ physics.end_paths : [ EndPath ]
 # set the event timing for OnSpill
 physics.producers.EWMProducer.SpillType : 1
 # define paths
-physics.trigger_paths : [ "0:DigitizePath", "1:TriggerablePath" , @sequence::Trig_physMenu.trigger_paths]
+physics.trigger_paths : [ "0:DigitizePath", "1:TriggerablePath" , "3:TriggerableTwoTrackPath", @sequence::Trig_physMenu.trigger_paths]
 # configure 'Triggered' output to be signal
 outputs.TriggeredOutput.SelectEvents : @local::Digitize.SignalTriggers
-outputs.TriggerableOutput.SelectEvents : [ "TriggerablePath" ]
+outputs.TriggerableOutput.SelectEvents : [ "TriggerablePath", "TriggerableTwoTrackPath" ]
 # Final configuration
 #include "Production/JobConfig/common/epilog.fcl"
 #include "Production/JobConfig/digitize/OnSpill_epilog.fcl"
 #include "mu2e-trig-config/core/trigDigiInputsEpilog.fcl"
 #include "Production/JobConfig/mixing/epilog.fcl"
-

--- a/JobConfig/mixing/Mix.fcl
+++ b/JobConfig/mixing/Mix.fcl
@@ -30,11 +30,13 @@ physics.end_paths : [ EndPath ]
 # final overrides
 # set the event timing for OnSpill
 physics.producers.EWMProducer.SpillType : 1
+# Define the default list of triggerable paths
+physics.TriggerablePaths : [ "TriggerableLHPath", "TriggerableTwoTrackPath"]
 # define paths
-physics.trigger_paths : [ "0:DigitizePath", "1:TriggerablePath" , "3:TriggerableTwoTrackPath", @sequence::Trig_physMenu.trigger_paths]
+physics.trigger_paths : [ "DigitizePath", @sequence::physics.TriggerablePaths, @sequence::Trig_physMenu.trigger_paths]
 # configure 'Triggered' output to be signal
 outputs.TriggeredOutput.SelectEvents : @local::Digitize.SignalTriggers
-outputs.TriggerableOutput.SelectEvents : [ "TriggerablePath", "TriggerableTwoTrackPath" ]
+outputs.TriggerableOutput.SelectEvents : [ @sequence::physics.TriggerablePaths ]
 # Final configuration
 #include "Production/JobConfig/common/epilog.fcl"
 #include "Production/JobConfig/digitize/OnSpill_epilog.fcl"

--- a/JobConfig/mixing/Mix.fcl
+++ b/JobConfig/mixing/Mix.fcl
@@ -17,7 +17,7 @@ physics : {
   analyzers: { @table::Digitize.analyzers }
   # define the digitization paths.  Trigger paths are added specific to digitization type
   DigitizePath : [ @sequence::Mixing.MixSequence ]
-  TriggerablePath : [ @sequence::Mixing.MixSequence, @sequence::Digitize.TriggerableSequence ]
+  TriggerableLHPath : [ @sequence::Mixing.MixSequence, @sequence::Digitize.TriggerableLHSequence ]
   TriggerableTwoTrackPath : [ @sequence::Mixing.MixSequence, @sequence::Digitize.TriggerableTwoTrackSequence ]
   # define the trigger sequences and paths
   @table::TrigRecoSequences

--- a/JobConfig/mixing/Mix.fcl
+++ b/JobConfig/mixing/Mix.fcl
@@ -18,7 +18,7 @@ physics : {
   # define the digitization paths.  Trigger paths are added specific to digitization type
   DigitizePath : [ @sequence::Mixing.MixSequence ]
   TriggerablePath : [ @sequence::Mixing.MixSequence, @sequence::Digitize.TriggerableSequence ]
-  TriggerableTwoTrackPath : [ @sequence::Digitize.DigitizeSequence, @sequence::Digitize.TriggerableTwoTrackSequence ]
+  TriggerableTwoTrackPath : [ @sequence::Mixing.MixSequence, @sequence::Digitize.TriggerableTwoTrackSequence ]
   # define the trigger sequences and paths
   @table::TrigRecoSequences
   @table::TrigSequences

--- a/JobConfig/mixing/Mix2Trk.fcl
+++ b/JobConfig/mixing/Mix2Trk.fcl
@@ -1,0 +1,5 @@
+# Configure digitization + mixing with a triggerable filter for two track events
+#include "Production/JobConfig/mixing/Mix.fcl"
+
+# Turn on the MC selection for two track events
+physics.filters.TriggerableTwoTrackPrescale.prescaleOffset : 0


### PR DESCRIPTION
Add an initial idea of a two-track "triggerable" MC selection to the digitization. This is off by default, where I've added specific fcl with this turned on for two track studies. This would target physics like photon conversions (RMC, RPC) and antiproton events. The threshold is initially very low as we study RMC conversions and how well we can trigger on events like coincident ~60 MeV/c + ~35 MeV/c electron-positron pairs. We will only generate these processes to begin with, but may turn this on in general as we turn on corresponding triggers.