### PR TITLE
new fcl + fcl changes

### DIFF
--- a/JobConfig/primary/FlatGamma.fcl
+++ b/JobConfig/primary/FlatGamma.fcl
@@ -5,7 +5,7 @@
 #
 #include "Production/JobConfig/primary/TargetStopParticle.fcl"
 physics.producers.generate : {
-  module_type            : FlatMuonDaughterGenerator
+  module_type            : FlatGeneratorFromStoppedMuon
   inputSimParticles      : TargetStopResampler
   stoppingTargetMaterial : "Al"
   pdgId                  : 22

--- a/JobConfig/primary/FlatMuMinus.fcl
+++ b/JobConfig/primary/FlatMuMinus.fcl
@@ -5,7 +5,7 @@
 #
 #include "Production/JobConfig/primary/TargetStopParticle.fcl"
 physics.producers.generate : {
-  module_type : FlatMuonDaughterGenerator
+  module_type : FlatGeneratorFromStoppedMuon
   inputSimParticles: TargetStopResampler
   stoppingTargetMaterial : "Al"
   pdgId : 13

--- a/JobConfig/primary/FlateMinus.fcl
+++ b/JobConfig/primary/FlateMinus.fcl
@@ -5,7 +5,7 @@
 #
 #include "Production/JobConfig/primary/TargetStopParticle.fcl"
 physics.producers.generate : {
-  module_type : FlatMuonDaughterGenerator
+  module_type : FlatGeneratorFromStoppedMuon
   inputSimParticles: TargetStopResampler
   stoppingTargetMaterial : "Al"
   pdgId : 11

--- a/JobConfig/primary/FlatePlus.fcl
+++ b/JobConfig/primary/FlatePlus.fcl
@@ -5,7 +5,7 @@
 #
 #include "Production/JobConfig/primary/TargetStopParticle.fcl"
 physics.producers.generate : {
-  module_type : FlatMuonDaughterGenerator
+  module_type : FlatGeneratorFromStoppedMuon
   inputSimParticles: TargetStopResampler
   stoppingTargetMaterial : "Al"
   pdgId : -11

--- a/JobConfig/primary/IPAMuminusFlateMinus.fcl
+++ b/JobConfig/primary/IPAMuminusFlateMinus.fcl
@@ -10,7 +10,7 @@ physics.filters.PrimaryFilter.MinimumPartMom : 30.0 // MeV/c TODO - tweak this p
 physics.producers.FindMCPrimary.PrimaryProcess : "mu2eFlateMinus"
 
 physics.producers.generate : {
-  module_type: FlatMuonDaughterGenerator
+  module_type: FlatGeneratorFromStoppedMuon
   inputSimParticles: IPAMuminusStopResampler
   stoppingTargetMaterial : "IPA"
   verbosity : 0

--- a/JobConfig/primary/RMCFlatGammaStops.fcl
+++ b/JobConfig/primary/RMCFlatGammaStops.fcl
@@ -12,7 +12,7 @@ outputs.IPAOutput.fileName    : "sim.owner.RMCFlatIPAGammaStops.version.sequence
 # Generation configuration
 
 physics.producers.generate : {
-  module_type            : FlatMuonDaughterGenerator
+  module_type            : FlatGeneratorFromStoppedMuon
   inputSimParticles      : TargetStopResampler
   stoppingTargetMaterial : "Al"
   pdgId                  : 22


### PR DESCRIPTION
New fcl relies on https://github.com/Mu2e/Offline/pull/1529

New FlatMuMinus.fcl for generating flat muon sample for PID model training. Changing momenta ranges on FlateMinus.fcl for PID training. Changing momenta ranges on FlatGamma.fcl for analysis on modeling RMC.