### PR TITLE
Reorganization of RPC generation and adding physical pion stop sampling

### DIFF
--- a/JobConfig/beam/PhysicalPionStops.fcl
+++ b/JobConfig/beam/PhysicalPionStops.fcl
@@ -1,0 +1,42 @@
+# Create a physical pion stop dataset from an infinite lifetime sample
+#include "Production/JobConfig/primary/StopParticle.fcl"
+
+process_name : PhysicalPionStops
+
+physics : {
+    producers : { }
+
+    filters : {
+        StopResampler : @local::physics.filters.TargetPiStopResampler
+
+        StopSelection : { # run accept/reject on a by-pion basis using lifetime weights
+            module_type     : StopSelection
+            simParticles    : StopResampler
+            stepPointMCs    : "StopResampler:virtualdetector"
+            pdgId           : -211
+            processCode     : @local::RPCInfo.pionStoppingCode
+            acceptRejectMax : 1e-3
+            decayOffPdgs    : [211, -211]
+            cuts            : {
+                tmin        : @local::RPCInfo.minPionStopTime
+            }
+            filter          : true
+            diagLevel       : 1
+        }
+    }
+
+    RPCPath : [ StopResampler, StopSelection ]
+    Output  : [ PionOutput ]
+    trigger_paths : [ RPCPath ]
+    end_paths     : [  Output ]
+}
+
+outputs : {
+    PionOutput : {
+        module_type : RootOutput
+        SelectEvents : [ RPCPath ]
+        fileName    : "sim.owner.PhysicalPionStops.version.sequencer.art"
+        # Only keep the sim particle collection produced by the stop selection
+        outputCommands : [ "keep *_*_*_*", "drop mu2e::SimParticlemv_StopResampler_*_*" ]
+    }
+}

--- a/JobConfig/primary/RPC.fcl
+++ b/JobConfig/primary/RPC.fcl
@@ -8,7 +8,7 @@
 
 physics.producers.generate : {
   module_type : RPCGun
-  inputSimParticles: TargetPiStopResampler
+  inputSimParticles: "StopSelector"
   verbosity : 0
   RPCType : @nil
   spectrum : {
@@ -20,6 +20,21 @@ physics.producers.generate : {
   pionDecayOff : true # will apply surv prob
   doHistograms : true
   #SurvivalProbScaling : 1
+}
+
+# Only sample late pion stops
+physics.filters.StopSelector : {
+    module_type     : StopSelection
+    simParticles    : TargetPiStopResampler
+    stepPointMCs    : "TargetPiStopResampler:virtualdetector"
+    pdgId           : -211
+    processCode     : @local::RPCInfo.pionStoppingCode
+    decayOffPdgs    : [211, -211]
+    cuts            : {
+        tmin        : @local::RPCInfo.minPionStopTime
+    }
+    filter          : true
+    diagLevel       : 1
 }
 
 physics.producers.FindMCPrimary.PrimaryProcess : @nil

--- a/JobConfig/primary/RPCPhysical.fcl
+++ b/JobConfig/primary/RPCPhysical.fcl
@@ -1,15 +1,18 @@
 ##
 # RPC photon spectrum, based on on Bistrilich spectrum
-# Use accept-reject method to produce a physical pion time distribution
+# Input created using accept-reject method to produce a physical pion time distribution
 #
 
 #include "Production/JobConfig/primary/RPC.fcl"
 
-physics.producers.RPCAcceptReject : @erase
-physics.filters.RPCAcceptReject : {
-    module_type : WeightSamplingFilter
-    inputTag            : generate
-    maximumWeight       : 1e-4 # Maximum time weight theoretically is e^-0 = 1, but (essentially) all RPC events have p(evt) < 1e-4, so increase sampling efficiency
-    debugLevel          : 1
-    makeHistograms      : true
+physics.filters.TargetPiStopResampler.mu2e.products : {
+    genParticleMixer: { mixingMap: [ [ "StopResampler", "" ] ] }
+    simParticleMixer: { mixingMap: [ [ "StopSelection", "" ] ] }
+    stepPointMCMixer: { mixingMap: [ [ "StopSelection", ":" ] ] }
+    volumeInfoMixer: {
+        srInput: "StopResampler"
+        evtOutInstanceName: "eventlevel"
+    }
 }
+physics.filters.StopSelector.stepPointMCs : "TargetPiStopResampler"
+physics.producers.generate.pionDecayOff : false

--- a/JobConfig/primary/TargetPiStopParticle.fcl
+++ b/JobConfig/primary/TargetPiStopParticle.fcl
@@ -4,13 +4,7 @@
 # original author: Dave Brown, LBNL
 # edited for pions by : Sophie Middleton
 #include "Production/JobConfig/primary/StopParticle.fcl"
-
-# Only filter if creating a physical spectrum
-physics.producers.RPCAcceptReject : {
-    module_type : NullProducer
-    nEngines : 1
-}
-physics.PrimaryPath : [ TargetPiStopResampler, @sequence::Common.generateSequence, RPCAcceptReject, @sequence::Common.g4Sequence, @sequence::Primary.PrimarySequence ]
+physics.PrimaryPath : [ TargetPiStopResampler, StopSelector, @sequence::Common.generateSequence, @sequence::Common.g4Sequence, @sequence::Primary.PrimarySequence ]
 physics.trigger_paths : [ PrimaryPath ]
 outputs : { PrimaryOutput : @local::Primary.PrimaryOutput }
 physics.EndPath : [ @sequence::Primary.EndSequence, PrimaryOutput ]

--- a/JobConfig/primary/prolog.fcl
+++ b/JobConfig/primary/prolog.fcl
@@ -152,6 +152,8 @@ Primary: {
       }
     }
 
+    StopSelector : { module_type : NullProducer }
+
     GammaConversionFilter : {
       module_type : GammaConversionPoints
       g4ModuleLabel : "g4run"
@@ -206,6 +208,12 @@ Primary: {
 RMCInfo : {
   kmaxMeasured : 90.1 # Measured as 90.1 +- 1.8
   kmaxEndpoint : 101.9 # Maximum photon kinematically allowed on aluminum
+}
+
+# RPC information
+RPCInfo : {
+    minPionStopTime  : 350. # minimum pion stop time considered, in ns
+    pionStoppingCode : 78 # hBertiniCaptureAtRest
 }
 
 StopFilter : {

--- a/Tests/PhysicalPionStops.fcl
+++ b/Tests/PhysicalPionStops.fcl
@@ -1,0 +1,24 @@
+# This file is for interactive tests to make physical pion stops from infinite lifetime pions
+#include "Production/JobConfig/beam/PhysicalPionStops.fcl"
+
+source.firstRun: 1201
+services.SeedService.baseSeed         :  8
+services.SeedService.maxUniqueEngines :  20
+
+outputs.PrimaryOutput.fileName : "sim.tester.PhysicalPionStops.Test.1.art"
+services.TFileService.fileName : "nts.tester.PhysicalPionStops.Test.1.root"
+
+physics.filters.StopResampler.mu2e.MaxEventsToSkip: 0
+physics.filters.StopResampler.fileNames : [
+                                           "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/dd/04/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000000.art",
+                                           "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/91/14/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000001.art",
+                                           "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/34/1d/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000002.art",
+                                           "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/cb/d3/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000003.art",
+                                           "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/5c/07/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000004.art",
+                                           "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/b1/13/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000005.art",
+                                           "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/fc/51/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000006.art",
+                                           "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/ed/cc/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000007.art",
+                                           "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/df/f8/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000008.art",
+                                           "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/7d/77/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000009.art"
+                                          ]
+

--- a/Tests/RPCSteps.fcl
+++ b/Tests/RPCSteps.fcl
@@ -1,16 +1,25 @@
 //
 // this file is for interactive tests to make RPCs from the filtered stops (fileNames)
 //
-#include "Production/JobConfig/primary/RPC.fcl"
+#include "Production/JobConfig/primary/RPCExternal.fcl"
 
 source.firstRun: 1201
-physics.filters.TargetPiStopResampler.fileNames : ["/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiMinusFilter/MDC2020aj/art/02/e7/sim.mu2e.PiMinusFilter.MDC2020aj.001201_00000899.art"]
-# change for Int/Ext:
-physics.producers.generate.RPCType : "mu2eExternalRPC"  
-physics.producers.FindMCPrimary.PrimaryProcess : "mu2eExternalRPC"
+physics.PrimaryPath : [ TargetPiStopResampler, StopSelector, generate, genCounter ]
+physics.producers.generate.verbosity : 0
 
 physics.filters.TargetPiStopResampler.mu2e.MaxEventsToSkip: 0
-physics.filters.TargetStopResampler.mu2e.MaxEventsToSkip: 0
 outputs.PrimaryOutput.fileName : "dts.tester.RPC.Test.1.art"
-services.TFileService.fileName: "nts.owner.GenPlots.version.sequencer.root"
+services.TFileService.fileName : "nts.tester.RPC.Test.1.root"
 
+physics.filters.TargetPiStopResampler.fileNames : [
+                                                   "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/dd/04/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000000.art",
+                                                   "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/91/14/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000001.art",
+                                                   "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/34/1d/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000002.art",
+                                                   "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/cb/d3/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000003.art",
+                                                   "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/5c/07/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000004.art",
+                                                   "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/b1/13/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000005.art",
+                                                   "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/fc/51/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000006.art",
+                                                   "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/ed/cc/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000007.art",
+                                                   "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/df/f8/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000008.art",
+                                                   "/pnfs/mu2e/tape/phy-sim/sim/mu2e/PiTargetStops/MDC2020aw/art/7d/77/sim.mu2e.PiTargetStops.MDC2020aw.001202_00000009.art"
+                                                   ]


### PR DESCRIPTION
This is in connection to the Offline RPC updates for the physical pion sampling. Pion stops are now selected using the `StopSelection` module, so the pion stop is consistent with the filters applied (e.g. the timing cut). The only thing I'm not sure about is where to put the physical pion stop dataset creation fcl, as it seems more part of the "beam" jobs, but I want to include the "primary" prolog to keep the RPC `tmin` cut the same and also get the resampling setup from there to not repeat logic. Should I move this to "primary" or keep it in "beam"?