### PR TITLE
Lower the Triggerable threshold to match the unprescaled triggers

### DIFF
--- a/JobConfig/digitize/prolog.fcl
+++ b/JobConfig/digitize/prolog.fcl
@@ -77,7 +77,7 @@ Digitize: {
     TriggerableLH : {
       module_type : StrawDigiMCFilter
       MinNDigis : 15
-      MinParticleMom : 75.0
+      MinParticleMom : 69.0  # lowest unprescaled single electron trigger is 70 MeV/c
       MaxParticleMom : 300.0 # nominally particles that can form Loophelices in the tracker
       StrawDigiMCCollection : compressDigiMCs
       particleTypes : [ 11,-11, 13, -13, 211, -211] # e+-, mu+-, pi+-


### PR DESCRIPTION
The positron trigger is set to 70 MeV/c and the electron trigger is likely going to be set to 75-80 MeV/c, so include MC tracks down to 69 MeV/c in "Triggerable" to better include these trigger regions.