### PR TITLE
Override the default geometry from Offline

### DIFF
--- a/JobConfig/common/epilog.fcl
+++ b/JobConfig/common/epilog.fcl
@@ -6,4 +6,5 @@ services.TimeTracker.printSummary: true
 services.scheduler.wantSummary: true
 #show summary of error logger
 services.message.destinations.log.outputStatistics : true
-
+# define the default geometry. This overrides the Offline default
+services.GeometryService.inputFile: "Offline/Mu2eG4/geom/geom_common.txt"


### PR DESCRIPTION
This change allows Production jobs to override the default geometry. It currently has no effect.