### PR TITLE
Remove overrides for CalLineTimePeakFinder

### DIFF
--- a/JobConfig/recoMC/NoFieldRun1B.fcl
+++ b/JobConfig/recoMC/NoFieldRun1B.fcl
@@ -42,11 +42,6 @@ physics.producers.CalTimeClusterFinder : {
   @table::CalPatRec.producers.CalTimeClusterFinder
   ComboHitCollectionLabel    : "makePH"
   CaloClusterCollectionLabel : "CaloClusterMaker"
-  MinTimeClusterHits         : 6
-  MinCaloClusterEnergy       : 50.
-  HitTimeSigmaThresh         : 3.
-  HitXYSigmaThresh           : 8.
-  StoppingTargetRadius       : 200.
 }
 
 # physics.producers.LineFinder.TimeClusterCollection : "TimeAndPhiClusterFinder"


### PR DESCRIPTION
This updates to use the defaults defined in the CalPatRec prolog, which have been recently "optimized." 