### PR TITLE
STM downstream simulation fcl updates

### DIFF
--- a/JobConfig/pileup/STM/VDResamplerConfigureTrainer.fcl
+++ b/JobConfig/pileup/STM/VDResamplerConfigureTrainer.fcl
@@ -24,7 +24,7 @@ physics: {
       SimParticlemvTag : "compressDetStepMCsSTM:"
       VirtualDetectorID : 116
       VDResamplerDir : "Offline/STMMC/VDResamplerFiles"
-      fclDir : "Production/pileup/STM"
+      fclDir : "Production/JobConfig/pileup/STM"
       dataSourceTag : MuBeam
       trainingThreshold : 100
       doROOTDump: true

--- a/JobConfig/pileup/STM/VDResamplerConfigureTrainer.fcl
+++ b/JobConfig/pileup/STM/VDResamplerConfigureTrainer.fcl
@@ -6,16 +6,10 @@
 
 process_name: VDResamplerConfigureTrainer
 
-source : {
-  module_type : RootInput
-  fileNames: @nil
-}
-services : {
-  message : @local::default_message
-  GlobalConstantsService : {
-    inputFile : "Offline/GlobalConstantsService/data/globalConstants_01.txt"
-  }
-}
+source : @local::STMPileup.VDResamplerSource
+
+services : @local::Services.Sim
+
 physics: {
   analyzers : {
     VDResamplerTrainingSetup : {

--- a/JobConfig/pileup/STM/VDResamplerConfigureTrainer.fcl
+++ b/JobConfig/pileup/STM/VDResamplerConfigureTrainer.fcl
@@ -20,17 +20,18 @@ physics: {
   analyzers : {
     VDResamplerTrainingSetup : {
       module_type : VDResamplerConfigure
-      StepPointMCsTag : @local::SimplifyStage1Data.StepPointMCsTag
-      SimParticlemvTag : @local::SimplifyStage1Data.SimParticlemvTag
+      StepPointMCsTag : "compressDetStepMCsSTM:"
+      SimParticlemvTag : "compressDetStepMCsSTM:"
       VirtualDetectorID : 116
       VDResamplerDir : "Offline/STMMC/VDResamplerFiles"
       fclDir : "Production/pileup/STM"
-      dataSourceTag : "MuBeam"
+      dataSourceTag : MuBeam
       trainingThreshold : 100
       doROOTDump: true
     }
   }
-  end_paths: [VDResamplerTrainingSetup]
+  o1: [VDResamplerTrainingSetup]
+  end_paths: [o1]
 }
 
 # if allows ROOTDump, specify output file name

--- a/JobConfig/pileup/STM/VDResamplerConfigureTrainer.fcl
+++ b/JobConfig/pileup/STM/VDResamplerConfigureTrainer.fcl
@@ -1,0 +1,37 @@
+# Provides a pass of the data and set up fcl's to train the SBDM models that 
+# describe particle distributions at a selected VD.
+
+#include "Offline/STMMC/fcl/prolog.fcl"
+#include "Offline/fcl/standardServices.fcl"
+
+process_name: VDResamplerConfigureTrainer
+
+source : {
+  module_type : RootInput
+  fileNames: @nil
+}
+services : {
+  message : @local::default_message
+  GlobalConstantsService : {
+    inputFile : "Offline/GlobalConstantsService/data/globalConstants_01.txt"
+  }
+}
+physics: {
+  analyzers : {
+    VDResamplerTrainingSetup : {
+      module_type : VDResamplerConfigure
+      StepPointMCsTag : @local::SimplifyStage1Data.StepPointMCsTag
+      SimParticlemvTag : @local::SimplifyStage1Data.SimParticlemvTag
+      VirtualDetectorID : 116
+      VDResamplerDir : "Offline/STMMC/VDResamplerFiles"
+      fclDir : "Production/pileup/STM"
+      dataSourceTag : "MuBeam"
+      trainingThreshold : 100
+      doROOTDump: true
+    }
+  }
+  end_paths: [VDResamplerTrainingSetup]
+}
+
+# if allows ROOTDump, specify output file name
+services.TFileService.fileName : @nil 

--- a/JobConfig/pileup/STM/VDResamplerGenerateFromModel.fcl
+++ b/JobConfig/pileup/STM/VDResamplerGenerateFromModel.fcl
@@ -31,7 +31,8 @@ physics: {
       doROOTDump: true
     }
   }
-  end_paths: [VDResamplerGenerator]
+  o1: [VDResamplerGenerator]
+  end_paths: [o1]
 }
 
 # if allows ROOTDump, specify output file name

--- a/JobConfig/pileup/STM/VDResamplerGenerateFromModel.fcl
+++ b/JobConfig/pileup/STM/VDResamplerGenerateFromModel.fcl
@@ -1,5 +1,5 @@
-# Provides a pass of the data and set up fcl's to train the SBDM models that 
-# describe particle distributions at a selected VD.
+# Generate samples from a single Score-Based Diffusion Model used for STM downstream resampler. 
+# A demonstrator of module function and allows root sample dump for study. 
 
 #include "Offline/STMMC/fcl/prolog.fcl"
 #include "Offline/fcl/standardServices.fcl"
@@ -18,16 +18,17 @@ services : {
 }
 physics: {
   producers : {
+    # replace either a pair of stage 1 and stage 2 model files or an allAtOnceModelFile for the placeholder while running this module
     VDResamplerGenerator : {
       module_type : VDResamplerGenerateFromModel
       useTwoStageModel: true
-      stage1ModelFile : "" 
-      stage2ModelFile : "" 
-      allAtOnceModelFile : "" 
+      stage1ModelFile : @nil 
+      stage2ModelFile : @nil 
+      allAtOnceModelFile : @nil  
       useHeun : true
       diffusionSteps : 200
-      # VDz0 : 37700.39
-      # VDr : 2000.0
+      # VDz0 : 37700.39 # z-coordinates of VD116. Only change when another VD is used
+      # VDr : 2000.0 # radius of VD116. Only change when another VD is used
       doROOTDump: true
     }
   }

--- a/JobConfig/pileup/STM/VDResamplerGenerateFromModel.fcl
+++ b/JobConfig/pileup/STM/VDResamplerGenerateFromModel.fcl
@@ -6,16 +6,10 @@
 
 process_name: VDResamplerGenerateFromModel
 
-source : {
-  module_type : RootInput
-  fileNames: @nil
-}
-services : {
-  message : @local::default_message
-  GlobalConstantsService : {
-    inputFile : "Offline/GlobalConstantsService/data/globalConstants_01.txt"
-  }
-}
+source : @local::STMPileup.VDResamplerSource
+
+services : @local::Services.Sim
+
 physics: {
   producers : {
     # replace either a pair of stage 1 and stage 2 model files or an allAtOnceModelFile for the placeholder while running this module

--- a/JobConfig/pileup/STM/VDResamplerGenerateFromModel.fcl
+++ b/JobConfig/pileup/STM/VDResamplerGenerateFromModel.fcl
@@ -1,0 +1,38 @@
+# Provides a pass of the data and set up fcl's to train the SBDM models that 
+# describe particle distributions at a selected VD.
+
+#include "Offline/STMMC/fcl/prolog.fcl"
+#include "Offline/fcl/standardServices.fcl"
+
+process_name: VDResamplerGenerateFromModel
+
+source : {
+  module_type : RootInput
+  fileNames: @nil
+}
+services : {
+  message : @local::default_message
+  GlobalConstantsService : {
+    inputFile : "Offline/GlobalConstantsService/data/globalConstants_01.txt"
+  }
+}
+physics: {
+  producers : {
+    VDResamplerGenerator : {
+      module_type : VDResamplerGenerateFromModel
+      useTwoStageModel: true
+      stage1ModelFile : "" 
+      stage2ModelFile : "" 
+      allAtOnceModelFile : "" 
+      useHeun : true
+      diffusionSteps : 200
+      # VDz0 : 37700.39
+      # VDr : 2000.0
+      doROOTDump: true
+    }
+  }
+  end_paths: [VDResamplerGenerator]
+}
+
+# if allows ROOTDump, specify output file name
+services.TFileService.fileName : @nil 

--- a/JobConfig/pileup/STM/VDResamplerGenerateMix.fcl
+++ b/JobConfig/pileup/STM/VDResamplerGenerateMix.fcl
@@ -31,7 +31,8 @@ physics: {
       doROOTDump: true
     }
   }
-  end_paths: [VDResamplerGenerator]
+  o1: [VDResamplerGenerator]
+  end_paths: [o1]
 }
 
 # if allows ROOTDump, specify output file name

--- a/JobConfig/pileup/STM/VDResamplerGenerateMix.fcl
+++ b/JobConfig/pileup/STM/VDResamplerGenerateMix.fcl
@@ -1,0 +1,38 @@
+# Provides a pass of the data and set up fcl's to train the SBDM models that 
+# describe particle distributions at a selected VD.
+
+#include "Offline/STMMC/fcl/prolog.fcl"
+#include "Offline/fcl/standardServices.fcl"
+
+process_name: VDResamplerGenerateMix
+
+source : {
+  module_type : RootInput
+  fileNames: @nil
+}
+services : {
+  message : @local::default_message
+  GlobalConstantsService : {
+    inputFile : "Offline/GlobalConstantsService/data/globalConstants_01.txt"
+  }
+}
+physics: {
+  producers : {
+    VDResamplerGenerator : {
+      module_type : VDResamplerGenerateMix
+      hitSummaryFiles : []
+      potsPerFile : []
+      ModelFileDir: "Offline/STMMC/VDResamplerFiles"
+      # VirtualDetectorID : 116
+      useHeun : true
+      diffusionSteps : 200
+      # VDz0 : 37700.39
+      # VDr : 2000.0
+      doROOTDump: true
+    }
+  }
+  end_paths: [VDResamplerGenerator]
+}
+
+# if allows ROOTDump, specify output file name
+services.TFileService.fileName : @nil 

--- a/JobConfig/pileup/STM/VDResamplerGenerateMix.fcl
+++ b/JobConfig/pileup/STM/VDResamplerGenerateMix.fcl
@@ -1,5 +1,6 @@
-# Provides a pass of the data and set up fcl's to train the SBDM models that 
-# describe particle distributions at a selected VD.
+# Generate samples from multiple Score-Based Diffusion Models from a list of sources. 
+# The samples from each source are mixed according to their corresponding POTs. 
+# A demonstrator of module function and allows root sample dump for study. 
 
 #include "Offline/STMMC/fcl/prolog.fcl"
 #include "Offline/fcl/standardServices.fcl"
@@ -18,16 +19,17 @@ services : {
 }
 physics: {
   producers : {
+    # Enter a list [aaa, bbb, ...] of hitSummaryFiles and a list of corresponding POTs at run
     VDResamplerGenerator : {
       module_type : VDResamplerGenerateMix
-      hitSummaryFiles : []
-      potsPerFile : []
+      hitSummaryFiles : @nil
+      potsPerFile : @nil
       ModelFileDir: "Offline/STMMC/VDResamplerFiles"
-      # VirtualDetectorID : 116
+      # VirtualDetectorID : 116 # default break-off point for STM downstream
       useHeun : true
       diffusionSteps : 200
-      # VDz0 : 37700.39
-      # VDr : 2000.0
+      # VDz0 : 37700.39 # z-coordinates of VD116. Only change when another VD is used
+      # VDr : 2000.0 # radius of VD116. Only change when another VD is used
       doROOTDump: true
     }
   }

--- a/JobConfig/pileup/STM/VDResamplerGenerateMix.fcl
+++ b/JobConfig/pileup/STM/VDResamplerGenerateMix.fcl
@@ -7,16 +7,10 @@
 
 process_name: VDResamplerGenerateMix
 
-source : {
-  module_type : RootInput
-  fileNames: @nil
-}
-services : {
-  message : @local::default_message
-  GlobalConstantsService : {
-    inputFile : "Offline/GlobalConstantsService/data/globalConstants_01.txt"
-  }
-}
+source : @local::STMPileup.VDResamplerSource
+
+services : @local::Services.Sim
+
 physics: {
   producers : {
     # Enter a list [aaa, bbb, ...] of hitSummaryFiles and a list of corresponding POTs at run

--- a/JobConfig/pileup/STM/prolog.fcl
+++ b/JobConfig/pileup/STM/prolog.fcl
@@ -50,6 +50,11 @@ STMPileup: {
   ]
   # define some common sequences
   stmResamplerSequence : [genCounter, protonTimeOffset, stmResampler]
+
+  VDResamplerSource : {
+    module_type : RootInput
+    fileNames: @nil
+  }
 }
 
 END_PROLOG

--- a/JobConfig/pileup/STM/prolog.fcl
+++ b/JobConfig/pileup/STM/prolog.fcl
@@ -42,8 +42,8 @@ STMPileup: {
     "keep art::EventIDs_*_*_*",
     "keep mu2e::GenParticles_*_*_*",
     "keep mu2e::GenEventCount_*_*_*", 
-    "keep mu2e::StepPointMCs_compressDetStepMCsSTM_*_*",
-    "keep mu2e::SimParticlemv_compressDetStepMCsSTM_*_*",
+    "keep mu2e::StepPointMCs_compressDetStepMCsSTM*_*_*",
+    "keep mu2e::SimParticlemv_compressDetStepMCsSTM*_*_*",
     "keep mu2e::SimTimeOffset_*_*_*",
     "keep mu2e::PhysicalVolumeInfomvs_g4run_*_*",
     "keep mu2e::StatusG4_*_*_*"


### PR DESCRIPTION
Addition of scripts to run the Score-Based Diffusion Model training and resampling for STM downstream simulations. Also fixed data product inclusion for the 2 data stream output propagating to VDs in the STM DS region.