### PR TITLE
Remove duplicate SelectReco calls

### DIFF
--- a/JobConfig/reco/prolog.fcl
+++ b/JobConfig/reco/prolog.fcl
@@ -365,21 +365,16 @@ Reconstruction.OnSpillPath : [
   SelectReco
 ]
 
-# OffSpill paths. Separate by fit type
-Reconstruction.OffSpillPath : [
+Reconstruction.CentralHelixPath : [
   @sequence::Reconstruction.PreTrk,
   @sequence::Reconstruction.OffSpillTrk,
-  SelectReco
-]
-
-Reconstruction.CentralHelixPath : [
-  @sequence::Reconstruction.OffSpillPath,
   CHFilter,
   SelectReco
 ]
 
 Reconstruction.LoopHelixPath : [
-  @sequence::Reconstruction.OffSpillPath,
+  @sequence::Reconstruction.PreTrk,
+  @sequence::Reconstruction.OffSpillTrk,
   LHFilter,
   SelectReco
 ]

--- a/JobConfig/recoMC/prolog.fcl
+++ b/JobConfig/recoMC/prolog.fcl
@@ -67,7 +67,7 @@ Reconstruction : {
   @table::Reconstruction
   # full MC sequence; form the Calo and CRV matching, and compress based on reco content
   # temporary build surface steps from StepPointMCs; this is a patch
-  MCReco :  [@sequence::CaloMC.TruthMatch,  CrvCoincidenceClusterMatchMC, SelectReco, compressRecoMCs, CrvCoincidenceClusterMCAssns ]
+  MCReco :  [@sequence::CaloMC.TruthMatch, CrvCoincidenceClusterMatchMC, compressRecoMCs, CrvCoincidenceClusterMCAssns ]
 
   # MC truth matched to reco
   HighRecoMCProducts : [
@@ -92,11 +92,6 @@ Reconstruction.NoFieldPath : [
 
 Reconstruction.OnSpillPath : [
   @sequence::Reconstruction.OnSpillPath,
-  @sequence::Reconstruction.MCReco
-]
-
-Reconstruction.OffSpillPath : [
-  @sequence::Reconstruction.OffSpillPath,
   @sequence::Reconstruction.MCReco
 ]
 


### PR DESCRIPTION
Cleanup to remove unused definition (OffSpillPath) and redundant calls to SelectReco in all the reco paths. Those calls were innocuous as art only invokes a module once, but having them was confusing.