### PR TITLE
Remove fireAll flag, as it is now done automatically

### DIFF
--- a/JobConfig/primary/MuCap1809keV.fcl
+++ b/JobConfig/primary/MuCap1809keV.fcl
@@ -12,7 +12,6 @@ physics.producers.generate : {
   decayProducts :
   {
     tool_type : MuCap1809keVGammaGenerator
-    fireAll   : true # Insert a photon into every event
   }
   verbosity : 0
 }


### PR DESCRIPTION
This fcl parameter is no longer defined, as it's done by the SingleProcessGenerator module