### PR TITLE
Add muon stop output for COL5 muon stops

### DIFF
--- a/JobConfig/pileup/MuBeamResampler.fcl
+++ b/JobConfig/pileup/MuBeamResampler.fcl
@@ -33,11 +33,12 @@ physics: {
   }
   # setup paths
   targetStopPath : [ @sequence::Pileup.beamResamplerSequence, @sequence::Common.g4Sequence, TargetStopPrescaleFilter, TargetMuonFinder, TargetStopFilter, compressPVTargetStops]
+  polyStopPath : [ @sequence::Pileup.beamResamplerSequence, @sequence::Common.g4Sequence, PolyStopPrescaleFilter, PolyMuonFinder, PolyStopFilter, compressPVPolyStops]
   IPAStopPath : [ @sequence::Pileup.beamResamplerSequence, @sequence::Common.g4Sequence, IPAMuonFinder, IPAStopFilter, compressPVIPAStops]
   flashPath : [ @sequence::Pileup.beamResamplerSequence, @sequence::Common.g4Sequence, @sequence::Pileup.flashSequence, @sequence::Pileup.DetStepSequence ]
   earlyFlashPath : [ @sequence::Pileup.beamResamplerSequence, @sequence::Common.g4Sequence, @sequence::Pileup.flashSequence, @sequence::Pileup.EarlyDetStepSequence ]
-  trigger_paths: [ flashPath, earlyFlashPath, targetStopPath, IPAStopPath ]
-  outPath : [ FlashOutput, EarlyFlashOutput, TargetStopOutput, IPAStopOutput ]
+  trigger_paths: [ flashPath, earlyFlashPath, targetStopPath, polyStopPath, IPAStopPath ]
+  outPath : [ FlashOutput, EarlyFlashOutput, TargetStopOutput, PolyStopOutput, IPAStopOutput ]
   end_paths: [outPath]
 }
 
@@ -49,6 +50,15 @@ outputs: {
     ]
     SelectEvents: [targetStopPath]
     fileName : "sim.owner.TargetStops.version.sequencer.art"
+  }
+
+  PolyStopOutput : {
+    module_type: RootOutput
+    outputCommands:   [ "drop *_*_*_*",
+      @sequence::Pileup.SimKeptProducts
+    ]
+    SelectEvents: [polyStopPath]
+    fileName : "sim.owner.PolyStops.version.sequencer.art"
   }
 
   IPAStopOutput : {
@@ -79,8 +89,9 @@ outputs: {
   }
 }
 # set prescale factors
-physics.filters.TargetStopPrescaleFilter.nPrescale         : @local::Pileup.MuminusTargetStopPrescale
-physics.filters.EarlyPrescaleFilter.nPrescale         : @local::Pileup.EarlyMuBeamFlashPrescale
+physics.filters.TargetStopPrescaleFilter.nPrescale : @local::Pileup.MuminusTargetStopPrescale
+physics.filters.PolyStopPrescaleFilter.nPrescale   : @local::Pileup.PolyStopPrescale
+physics.filters.EarlyPrescaleFilter.nPrescale      : @local::Pileup.EarlyMuBeamFlashPrescale
 
 # Point Mu2eG4 to the pre-simulated data
 physics.producers.g4run.inputs: {

--- a/JobConfig/pileup/prolog.fcl
+++ b/JobConfig/pileup/prolog.fcl
@@ -44,6 +44,15 @@ Pileup: {
       stoppingMaterial: "StoppingTarget_Al"
       verbosityLevel: 1
     }
+    PolyMuonFinder: {
+      module_type: "StoppedParticlesFinder"
+      particleInput: "g4run"
+      particleTypes: [ 13, -13 ]
+      physVolInfoInput: "g4run:eventlevel"
+      useEventLevelVolumeInfo: true
+      stoppingMaterial: "COL5Poly"
+      verbosityLevel: 1
+    }
     WireGammaFinder: {
       module_type: "StoppedParticlesFinder"
       particleInput: "g4run"
@@ -81,11 +90,24 @@ Pileup: {
       processes: [ "DIO", "NuclearCapture" ] //TODO
     }
 
+    stoppedPolyMuonDaughters: {
+      module_type: SimParticleDaughterSelector
+      particleInput: "PolyMuonFinder"
+      # EMCascade should not be vetoed because we do not re-simulate it
+      processes: [ "DIO", "NuclearCapture" ] //TODO
+    }
+
     compressPVTargetStops: {
       module_type: CompressPhysicalVolumes
       volumesInput : "g4run"
       hitInputs : []
       particleInputs : [ "TargetStopFilter" ]
+    }
+    compressPVPolyStops: {
+      module_type: CompressPhysicalVolumes
+      volumesInput : "g4run"
+      hitInputs : []
+      particleInputs : [ "PolyStopFilter" ]
     }
     compressPVWireStops: {
       module_type: CompressPhysicalVolumes
@@ -135,6 +157,12 @@ Pileup: {
       extraHitInputs: [ "g4run:virtualdetector" ]
       mainSPPtrInputs: [ "TargetMuonFinder" ]
     }
+    PolyStopFilter: {
+      module_type: FilterG4Out
+      mainHitInputs: []
+      extraHitInputs: [ "g4run:virtualdetector" ]
+      mainSPPtrInputs: [ "PolyMuonFinder" ]
+    }
     WireStopFilter: {
       module_type: FilterG4Out
       mainHitInputs: []
@@ -164,6 +192,9 @@ Pileup: {
     }
 
     TargetStopPrescaleFilter : {
+      module_type : RandomPrescaleFilter
+    }
+    PolyStopPrescaleFilter : {
       module_type : RandomPrescaleFilter
     }
     EarlyPrescaleFilter : {
@@ -333,6 +364,7 @@ Pileup: {
   EarlyMuBeamFlashPrescale : 30
   EarlyNeutralsFlashPrescale : 20
   MuminusTargetStopPrescale : 1000
+  PolyStopPrescale : 1000
 }
 # DetctorStepFilter instance to select DetSteps outside the flash
 Pileup.filters.DetStepFilter : {


### PR DESCRIPTION
These stops are important for RMC analyses, as the photons produced can reach the calorimeter. This relies on PR https://github.com/Mu2e/Offline/pull/1817 which creates a unique name for the COL5 material in order to select these stops.