### PR TITLE
Update calo signal primaries with calo dts filter change

### DIFF
--- a/JobConfig/digitize/prolog.fcl
+++ b/JobConfig/digitize/prolog.fcl
@@ -139,7 +139,7 @@ Digitize: {
     # Triggerable calo events
     TriggerableCalo : {
       module_type : CaloShowerSimFilter
-      MinParticleEnergy : 75.0
+      MinParticleEnergy : 68.0
       MinTotalEnergy    : 1e6
       CaloShowerSimCollection : "compressDigiMCs"
       particleTypes : [11, -11, 13, -13, 211, -211, 22]

--- a/JobConfig/primary/FlatGammaCalo.fcl
+++ b/JobConfig/primary/FlatGammaCalo.fcl
@@ -9,8 +9,5 @@ physics.producers.generate.czMax    : 0.999
 physics.producers.generate.startMom : 50
 physics.producers.generate.endMom   : 110
 
-physics.filters.PrimaryFilter.MinimumPartMom : 1
-physics.filters.PrimaryFilter.MinimumSumCaloStepE : 50
-
 physics.producers.FindMCPrimary.PrimaryProcess : "mu2eFlatPhoton"
 outputs.PrimaryOutput.fileName: "dts.owner.FlatGammaCalo.version.sequencer.art"

--- a/JobConfig/primary/MuCap1809keVCalo.fcl
+++ b/JobConfig/primary/MuCap1809keVCalo.fcl
@@ -8,3 +8,7 @@
 physics.producers.generate.decayProducts.czmin : 0.99
 physics.producers.generate.decayProducts.czmax : 1.
 outputs.PrimaryOutput.fileName: "dts.owner.MuCap1809keVCalo.version.sequencer.art"
+
+physics.filters.PrimaryFilter.MinimumCaloPartMom  : 0.
+physics.filters.PrimaryFilter.MinimumSumCaloStepE : 0.1
+physics.filters.PrimaryFilter.MinimumSumCaloE     : 0.1

--- a/JobConfig/primary/RMCExternal.fcl
+++ b/JobConfig/primary/RMCExternal.fcl
@@ -4,7 +4,9 @@
 
 #include "Production/JobConfig/primary/RMC.fcl"
 
-physics.filters.PrimaryFilter.MinimumPartMom : 80.
+physics.filters.PrimaryFilter.MinimumPartMom      : 80.
+physics.filters.PrimaryFilter.MinimumSumCaloStepE : 80.
+physics.filters.PrimaryFilter.MinimumSumCaloE     : 80.
 physics.producers.generate.decayProducts.mode : "external"
 physics.producers.FindMCPrimary.PrimaryProcess : "mu2eExternalRMC"
 outputs.PrimaryOutput.fileName : "dts.owner.RMCExternal.version.sequencer.art"

--- a/JobConfig/primary/prolog.fcl
+++ b/JobConfig/primary/prolog.fcl
@@ -63,9 +63,12 @@ Primary: {
       MinimumCrvSteps : 1
       MinimumPartMom : 50.0 # MeV/c
       MaximumPartMom : 1.0e6 # MeV/c
+      MinimumCaloPartMom : 0.0 # MeV
+      MaximumCaloPartMom : 1.0e6 # MeV
       KeepPDG : [ ] # Loop at steps from all particle types
       MinimumTrkSteps : 12 # primary must produce at least this many TrkSteps
-      MinimumSumCaloStepE : 45.0 # or at least this much calo energy
+      MinimumSumCaloStepE : 45.0 # or at least this much calo energy by a single sim particle
+      MinimumSumCaloE : 45.0 # or at least this much calo total energy by accepted sim particles
     }
 
     TargetStopResampler : {


### PR DESCRIPTION
This follows the changes in Offline PR https://github.com/Mu2e/Offline/pull/1819. Primaries with calo signals can now be selected with total calo energy deposits, and the calo momentum in threshold on sims is lowered. This should reduce loss of viable signals that shower in the calo. The triggerable threshold is also reduced to 68 MeV for calo signals, reflecting the lowered energy reachable by the NN-based calo triggers for electrons and photons.