### PR TITLE
Match the FlateMinus and FlatePlus energy ranges

### DIFF
--- a/JobConfig/primary/FlatePlus.fcl
+++ b/JobConfig/primary/FlatePlus.fcl
@@ -9,6 +9,8 @@ physics.producers.generate : {
   inputSimParticles: TargetStopResampler
   stoppingTargetMaterial : "Al"
   pdgId : -11
+  startMom : 70
+  endMom : 110
   verbosity : 0
 }
 


### PR DESCRIPTION
The range isn't defined in fcl currently, where the recent MDC2025 dataset appears to use 90 - 110 MeV. This isn't ideal for mu- --> e+ work where we use this sample to model internal RMC spectra. This update matches it to the flat electron configuration, though exact matching between them isn't necessary.