### PR TITLE
Add 'Detailed' reco output and use it for NoField

### DIFF
--- a/JobConfig/reco/NoField.fcl
+++ b/JobConfig/reco/NoField.fcl
@@ -5,12 +5,11 @@
 #
 outputs: {
   KinematicLineOutput : {
-    @table::Reconstruction.Output
+    @table::Reconstruction.DetailedOutput
     SelectEvents : [ "RecoPath" ]
     fileName: "rec.owner.description.version.sequencer.art"
   }
 }
-
 physics.RecoPath : [ @sequence::Reconstruction.NoFieldPath ]
 physics.EndPath : [ KinematicLineOutput]
 physics.trigger_paths : [ RecoPath ]

--- a/JobConfig/reco/prolog.fcl
+++ b/JobConfig/reco/prolog.fcl
@@ -318,14 +318,13 @@ Reconstruction : {
   ]
   # Low reco products, useful for debugging and event display
   LowRecoProducts : [
-    "keep mu2e::ComboHits_*_*_*"
+    "keep mu2e::ComboHitCollection_*_*_*"
   ]
   GeneralProducts : [
     @sequence::Digitize.GeneralProducts,
     @sequence::Digitize.TriggerProducts # not sure we want to keep these
   ]
   # TODO: add products from reconstruction-level estimates of PBI from tracker and calorimeter
-
 }
 
 # OnSpill track reconstruction sequence: LoopHelix electrons and muons, downstream and upstream
@@ -388,7 +387,15 @@ Reconstruction.Output : {
     @sequence::Reconstruction.MidRecoProducts
   ]
 }
-
+# detailed output
+Reconstruction.DetailedOutput : {
+  @table::Reconstruction.Output
+  outputCommands: [
+  @sequence::Reconstruction.Output.outputCommands,
+  @sequence::Reconstruction.LowRecoProducts
+  ]
+}
+# customize for KalSeed regrow
 Reconstruction.RegrowOutput : {
   module_type : RootOutput
   fileName    : @nil

--- a/JobConfig/recoMC/NoField.fcl
+++ b/JobConfig/recoMC/NoField.fcl
@@ -5,7 +5,7 @@
 #
 outputs: {
   KinematicLineOutput : {
-    @table::Reconstruction.Output
+    @table::Reconstruction.DetailedOutput
     SelectEvents : [ "RecoPath" ]
     fileName: "mcs.owner.description.version.sequencer.art"
   }

--- a/JobConfig/recoMC/prolog.fcl
+++ b/JobConfig/recoMC/prolog.fcl
@@ -105,15 +105,17 @@ Reconstruction.LoopHelixPath : [
   @sequence::Reconstruction.MCReco
 ]
 
-# MC-specific output
-Reconstruction.Output : {
-  @table::Reconstruction.Output
-  outputCommands : [ "drop *_*_*_*",
-    @sequence::Reconstruction.GeneralProducts,
-    @sequence::Reconstruction.GeneralMCProducts,
-    @sequence::Reconstruction.HighRecoProducts,
-    @sequence::Reconstruction.HighRecoMCProducts,
-    @sequence::Reconstruction.MidRecoProducts
-  ]
-}
+# add MC-specific payload
+Reconstruction.Output : @local::Reconstruction.Output
+Reconstruction.Output.outputCommands : [
+  @sequence::Reconstruction.Output.outputCommands,
+  @sequence::Reconstruction.GeneralMCProducts,
+  @sequence::Reconstruction.HighRecoMCProducts
+]
+Reconstruction.DetailedOutput : @local::Reconstruction.DetailedOutput
+Reconstruction.DetailedOutput.outputCommands : [
+  @sequence::Reconstruction.DetailedOutput.outputCommands,
+  @sequence::Reconstruction.GeneralMCProducts,
+  @sequence::Reconstruction.HighRecoMCProducts
+]
 END_PROLOG


### PR DESCRIPTION
This PR adds ComboHits to the payload of NoField (Extracted and FieldOff) production reco output. These are used in debugging and EventDisplay.