### PR TITLE
Add fcl to produce approximate pileup for poly muon stops

### DIFF
--- a/JobConfig/pileup/MuPolyStopPileup.fcl
+++ b/JobConfig/pileup/MuPolyStopPileup.fcl
@@ -1,0 +1,32 @@
+#
+# generate and produce Detector Steps from generic muon poly stops
+# Uses the Pileup 'generator' from A. Gaponenko
+# Assumes proton, neutron, and RMC distributions/rates per capture are similar to Al
+#
+#include "Production/JobConfig/pileup/MuStopPileup.fcl"
+
+process_name: MuPolyStopPileup
+physics.producers.generate : {
+  module_type: Pileup
+  inputSimParticles: TargetStopResampler
+  stoppingTargetMaterial : "C" # Assume carbon stops
+  verbosity: 1
+  captureProducts: [
+    @local::Pileup.muonCaptureProtonGenTool,
+    @local::Pileup.muonCaptureDeuteronGenTool,
+    @local::Pileup.muonCaptureNeutronGenTool,
+    @local::Pileup.muonCaptureRMCGenTool
+  ]
+  decayProducts: [
+    @local::Pileup.dioGenTool
+  ]
+}
+outputs.Output.fileName: "dts.owner.MuPolyStopPileup.version.sequencer.art"
+
+# Change to DIO on Carbon
+physics.producers.generate.decayProducts[0].spectrum.spectrumShape   : "tabulated"
+physics.producers.generate.decayProducts[0].spectrum.spectrumVariable: "totalEnergy"
+physics.producers.generate.decayProducts[0].spectrum.spectrumFileName: "Offline/EventGenerator/data/heeck_finer_binning_2016_szafron-scaled-to-6C.tbl"
+physics.producers.generate.decayProducts[0].spectrum.elow: 1.0
+physics.producers.generate.decayProducts[0].spectrum.ehi : 105.1
+

--- a/Tests/MuPolyStopPileup.fcl
+++ b/Tests/MuPolyStopPileup.fcl
@@ -1,0 +1,9 @@
+#include "Production/JobConfig/pileup/MuPolyStopPileup.fcl"
+#include "Production/Tests/MuonStopConfig.fcl"
+
+services.SeedService.baseSeed : @local::Common.BaseSeed
+services.TFileService.fileName: "nts.owner.MuPolyStopPileup.version.sequencer.root"
+
+physics.filters.TargetStopResampler.fileNames : [
+"/pnfs/mu2e/persistent/datasets/phy-sim/sim/mu2e/PolyStops/Run1Ban-001/art/12/7b/sim.mu2e.PolyStops.Run1Ban-001.001470_00000000.art"
+]


### PR DESCRIPTION
This can be used to produce pileup from muon stops in the COL5 poly. It assumes all stops are on carbon and that the proton/neutron/deuteron spectra are similar to the aluminum spectra, but normalized to the Geant4 carbon capture rates. This is connected to Offline PR https://github.com/Mu2e/Offline/pull/1867