### PR TITLE
update conditions set for new CRV geometry

### DIFF
--- a/Validation/database.fcl
+++ b/Validation/database.fcl
@@ -2,5 +2,5 @@
 # Database configuration for validation and CI jobs
 #
 services.DbService.purpose: Sim_best
-services.DbService.version: v1_4
+services.DbService.version: v1_5
 services.DbService.verbose : 2


### PR DESCRIPTION
This changes the database conditions set from Sim_best v1_4 to v1_5.  I believe this change is only to accommodate a change to the CRV extracted geometry.  I see it is included in EventNtuple, Offline/CrvResponse/test, and mu2e-trig-config/test so I added a few reviewers.  Maybe @bonventre can advise how to migrate those uses away from this validation fcl