### PR TITLE
Add fcl to generate RMC photons from COL5 poly muon stops

### DIFF
--- a/JobConfig/pileup/PolyMuonStopSelector.fcl
+++ b/JobConfig/pileup/PolyMuonStopSelector.fcl
@@ -1,0 +1,8 @@
+# Filter Muminus and Muplus COL5 poly stops from combined stops and write them to a file
+
+#include "Production/JobConfig/pileup/MuonStopSelector.fcl"
+
+physics.filters.muminusSelector.SimParticles : "PolyStopFilter"
+physics.filters.muplusSelector.SimParticles  : "PolyStopFilter"
+outputs.muminusout.fileName : "sim.owner.MuminusPolyStopsCat.version.sequencer.art"
+outputs.muplusout.fileName  : "sim.owner.MuplusPolyStopsCat.version.sequencer.art"

--- a/JobConfig/primary/PolyFlatGamma.fcl
+++ b/JobConfig/primary/PolyFlatGamma.fcl
@@ -1,0 +1,28 @@
+#
+# generate and produce Detector Steps from flat spectrum using mu- COL5 poly stops
+#
+# original author: M. MacKenzie
+#
+#include "Production/JobConfig/primary/TargetStopParticle.fcl"
+physics.producers.generate : {
+  module_type            : FlatGeneratorFromStoppedMuon
+  inputSimParticles      : TargetStopResampler
+  stoppingTargetMaterial : "C"
+  pdgId                  : 22
+  startMom               : 50
+  endMom                 : 110
+  verbosity              : 0
+}
+physics.filters.TargetStopResampler.mu2e.products : {
+  genParticleMixer: { mixingMap: [ [ "beamResampler", "" ] ] }
+  simParticleMixer: { mixingMap: [ [ "PolyStopFilter", "" ] ] }
+  stepPointMCMixer: { mixingMap: [ [ "PolyStopFilter:virtualdetector", ":" ] ] }
+  volumeInfoMixer: {
+    srInput: "compressPVPolyStops"
+    evtOutInstanceName: "eventlevel"
+  }
+
+}
+
+physics.producers.FindMCPrimary.PrimaryProcess : "mu2eFlatPhoton"
+outputs.PrimaryOutput.fileName: "dts.owner.PolyFlatGamma.version.sequencer.art"

--- a/JobConfig/primary/PolyFlatGammaCalo.fcl
+++ b/JobConfig/primary/PolyFlatGammaCalo.fcl
@@ -1,0 +1,13 @@
+#
+# generate and produce Detector Steps from flat photon spectrum using mu- COL5 poly stops, aimed at the calorimeter
+#
+# original author: M. MacKenzie
+#
+#include "Production/JobConfig/primary/PolyFlatGamma.fcl"
+physics.producers.generate.czMin    : 0.99
+physics.producers.generate.czMax    : 1.
+physics.producers.generate.startMom : 50
+physics.producers.generate.endMom   : 110
+
+physics.producers.FindMCPrimary.PrimaryProcess : "mu2eFlatPhoton"
+outputs.PrimaryOutput.fileName: "dts.owner.PolyFlatGammaCalo.version.sequencer.art"

--- a/Tests/PolyFlatGamma.fcl
+++ b/Tests/PolyFlatGamma.fcl
@@ -7,5 +7,3 @@ services.TFileService.fileName: "nts.owner.PolyFlatGamma.version.sequencer.root"
 physics.filters.TargetStopResampler.fileNames : [
   "sim.owner.MuminusPolyStopsCat.version.sequencer.art"
 ]
-
-physics.PrimaryPath : [ TargetStopResampler, generate, genCounter ]

--- a/Tests/PolyFlatGamma.fcl
+++ b/Tests/PolyFlatGamma.fcl
@@ -1,0 +1,11 @@
+#include "Production/JobConfig/primary/PolyFlatGammaCalo.fcl"
+#include "Production/Tests/MuonStopConfig.fcl"
+
+services.SeedService.baseSeed : @local::Common.BaseSeed
+services.TFileService.fileName: "nts.owner.PolyFlatGamma.version.sequencer.root"
+
+physics.filters.TargetStopResampler.fileNames : [
+  "sim.owner.MuminusPolyStopsCat.version.sequencer.art"
+]
+
+physics.PrimaryPath : [ TargetStopResampler, generate, genCounter ]


### PR DESCRIPTION
Starting with flat photons from muon stops in the COL5 poly. These will be relevant to RMC measurement studies as these photons can make it to the detectors, unlike the highly surpressed DIO electrons in COL5.