### PR TITLE
Neutron tail simulation

### DIFF
--- a/JobConfig/primary/MuCapNeutronTail.fcl
+++ b/JobConfig/primary/MuCapNeutronTail.fcl
@@ -1,0 +1,26 @@
+#
+# Generate high KE muon capture neutrons
+#
+# Original author: Michael MacKenzie, 2026
+#
+#include "Production/JobConfig/primary/TargetStopParticle.fcl"
+
+physics.producers.generate : {
+  module_type : SingleProcessGenerator
+  inputSimParticles: TargetStopResampler
+  stoppingTargetMaterial : "Al"
+  decayProducts :
+  {
+    tool_type : MuCapNeutronGenerator
+    spectrumVariable : kineticEnergy
+    spectrum : {
+      spectrumShape: tabulated
+      spectrumFileName: "Offline/EventGenerator/data/SchroederNeutronSpectrum.txt"
+      elow : 60.
+    }
+  }
+  verbosity : 0
+}
+
+physics.producers.FindMCPrimary.PrimaryProcess : "mu2eMuonCaptureAtRest"
+outputs.PrimaryOutput.fileName: "dts.owner.MuCapNeutronTail.version.sequencer.art"

--- a/JobConfig/primary/MuCapNeutronTailCalo.fcl
+++ b/JobConfig/primary/MuCapNeutronTailCalo.fcl
@@ -1,0 +1,10 @@
+#
+# Generate high energy muon capture neutrons, aimed at the calorimeter
+#
+# Original author: Michael MacKenzie, 2026
+#
+#include "Production/JobConfig/primary/MuCapNeutronTail.fcl"
+
+physics.producers.generate.decayProducts.czmin : 0.99
+physics.producers.generate.decayProducts.czmax : 1.
+outputs.PrimaryOutput.fileName: "dts.owner.MuCapNeutronCalo.version.sequencer.art"

--- a/JobConfig/primary/prolog.fcl
+++ b/JobConfig/primary/prolog.fcl
@@ -188,7 +188,8 @@ Primary: {
     "keep mu2e::EventWeight_*_*_*",
     "keep art::TriggerResults_*_*_*",
     "keep mu2e::StepPointMCs_CosmicResampler_crvStage1_*", # this is needed to keep track of low/all CRV split
-    "keep mu2e::PrimaryParticle_*_*_*"
+    "keep mu2e::PrimaryParticle_*_*_*",
+    "keep mu2e::SpectrumConfig_*_*_*"
   ]
 
   StepProducts : [

--- a/Tests/MuCapNeutronTailSteps.fcl
+++ b/Tests/MuCapNeutronTailSteps.fcl
@@ -1,0 +1,4 @@
+#include "Production/JobConfig/primary/MuCapNeutronTailCalo.fcl"
+#include "Production/Tests/MuonStopConfig.fcl"
+
+services.TFileService.fileName: "nts.owner.test.version.sequencer.root"

--- a/Tests/MuCapNeutronTailSteps.fcl
+++ b/Tests/MuCapNeutronTailSteps.fcl
@@ -1,4 +1,4 @@
-#include "Production/JobConfig/primary/MuCapNeutronTailCalo.fcl"
+#include "Production/JobConfig/primary/MuCapNeutronTail.fcl"
 #include "Production/Tests/MuonStopConfig.fcl"
 
 services.TFileService.fileName: "nts.owner.test.version.sequencer.root"


### PR DESCRIPTION
Add neutron tail primaries for calo cluster studies, add missing product line. This is for calo cluster background studies and is connected to Offline PR https://github.com/Mu2e/Offline/pull/1878