### PR TITLE
Add RMC phase-space approximation fcl

### DIFF
--- a/JobConfig/primary/RMCPhaseSpace0NExternal.fcl
+++ b/JobConfig/primary/RMCPhaseSpace0NExternal.fcl
@@ -1,0 +1,13 @@
+#
+# RMC External, phase-space model with 0 knockout
+#
+
+#include "Production/JobConfig/primary/RMCExternal.fcl"
+
+physics.producers.generate.decayProducts.spectrum.phaseSpaceShape : true
+physics.producers.generate.decayProducts.spectrum.nKnockout : 0
+physics.producers.generate.decayProducts.spectrum.elow : 80.
+physics.producers.generate.decayProducts.spectrum.ehi  : 105.
+
+
+outputs.PrimaryOutput.fileName : "dts.owner.RMCPhaseSpace0NExternal.version.sequencer.art"

--- a/JobConfig/primary/RMCPhaseSpace0NInternal.fcl
+++ b/JobConfig/primary/RMCPhaseSpace0NInternal.fcl
@@ -1,0 +1,14 @@
+#
+# RMC External, phase-space model with 0 knockout
+#
+
+#include "Production/JobConfig/primary/RMCInternal.fcl"
+
+physics.producers.generate.decayProducts.spectrum.phaseSpaceShape : true
+physics.producers.generate.decayProducts.spectrum.nKnockout : 0
+physics.producers.generate.decayProducts.spectrum.elow : 80.
+physics.producers.generate.decayProducts.spectrum.ehi  : 105.
+physics.filters.GenFilter.emin : 79.
+
+
+outputs.PrimaryOutput.fileName : "dts.owner.RMCPhaseSpace0NInternal.version.sequencer.art"

--- a/JobConfig/primary/RMCPhaseSpace0NInternal.fcl
+++ b/JobConfig/primary/RMCPhaseSpace0NInternal.fcl
@@ -1,5 +1,5 @@
 #
-# RMC External, phase-space model with 0 knockout
+# RMC Internal, phase-space model with 0 knockout
 #
 
 #include "Production/JobConfig/primary/RMCInternal.fcl"

--- a/JobConfig/primary/RMCPhaseSpace1NExternal.fcl
+++ b/JobConfig/primary/RMCPhaseSpace1NExternal.fcl
@@ -1,0 +1,9 @@
+#
+# RMC External, phase-space model with 1 knockout
+#
+
+#include "Production/JobConfig/primary/RMCPhaseSpace0NExternal.fcl"
+
+physics.producers.generate.decayProducts.spectrum.nKnockout : 1
+
+outputs.PrimaryOutput.fileName : "dts.owner.RMCPhaseSpace1NExternal.version.sequencer.art"

--- a/JobConfig/primary/RMCPhaseSpace1NInternal.fcl
+++ b/JobConfig/primary/RMCPhaseSpace1NInternal.fcl
@@ -1,5 +1,5 @@
 #
-# RMC External, phase-space model with 1 knockout
+# RMC Internal, phase-space model with 1 knockout
 #
 
 #include "Production/JobConfig/primary/RMCPhaseSpace0NInternal.fcl"

--- a/JobConfig/primary/RMCPhaseSpace1NInternal.fcl
+++ b/JobConfig/primary/RMCPhaseSpace1NInternal.fcl
@@ -1,0 +1,9 @@
+#
+# RMC External, phase-space model with 1 knockout
+#
+
+#include "Production/JobConfig/primary/RMCPhaseSpace0NInternal.fcl"
+
+physics.producers.generate.decayProducts.spectrum.nKnockout : 1
+
+outputs.PrimaryOutput.fileName : "dts.owner.RMCPhaseSpace1NInternal.version.sequencer.art"

--- a/Tests/RMCPhaseSpace0NExternal.fcl
+++ b/Tests/RMCPhaseSpace0NExternal.fcl
@@ -1,0 +1,5 @@
+#include "Production/JobConfig/primary/RMCPhaseSpace0NExternal.fcl"
+#include "Production/Tests/MuonStopConfig.fcl"
+
+physics.producers.generate.decayProducts.makeHistograms : true
+services.TFileService.fileName: "nts.owner.RMCPhaseSpace0NExternal.version.sequencer.root"


### PR DESCRIPTION
This is connected to Offline PR: https://github.com/Mu2e/Offline/pull/1879. This adds fcl to generator the 0 and 1 neutron knockout RMC spectra. These can then be used in mu- --> e- and mu- --> e+ analyses using the branching fractions measured in recent studies.