### PR TITLE
Update Run 1B reco

### DIFF
--- a/JobConfig/digitize/prolog.fcl
+++ b/JobConfig/digitize/prolog.fcl
@@ -67,26 +67,31 @@ Digitize: {
       @table::CommonMC.TTSelectRecoMC
       ComboHitCollection : "TrigFlagPH"
       KalSeedCollections  : [ "TrigAprKSF" ]
+      TimeClusterCollections : [ ]
     }
     TrigAprUeKSFMC : {
       @table::CommonMC.TTSelectRecoMC
       ComboHitCollection : "TrigFlagPH"
       KalSeedCollections  : [ "TrigAprUeKSF" ]
+      TimeClusterCollections : [ ]
     }
     TrigTprDeKSFMC : {
       @table::CommonMC.TTSelectRecoMC
       ComboHitCollection : "TrigFlagPH"
       KalSeedCollections  : [ "TrigKSFDe" ]
+      TimeClusterCollections : [ ]
     }
     TrigMprDeKSFMC : {
       @table::CommonMC.TTSelectRecoMC
       ComboHitCollection : "TrigFlagPH"
       KalSeedCollections  : [ "TrigKSFMprDe" ]
+      TimeClusterCollections : [ ]
     }
     TrigCprDeKSFMC : {
       @table::CommonMC.TTSelectRecoMC
       ComboHitCollection : "TrigFlagPH"
       KalSeedCollections  : [ "TrigCalSeedFitDe" ]
+      TimeClusterCollections : [ ]
     }
   }
   filters : {

--- a/JobConfig/reco/prolog.fcl
+++ b/JobConfig/reco/prolog.fcl
@@ -112,6 +112,7 @@ Reconstruction : {
       CaloClusterCollection : "CaloClusterMaker"
       CrvCoincidenceClusterCollection : "CrvCoincidenceClusterFinder"
       KalSeedCollections  : [ "KKDe", "KKDmu", "KKUe", "KKUmu", "KKLine", "KKCHmu" ]
+      TimeClusterCollections : [ ]
     }
     # regrow
     RegrowSH : {

--- a/JobConfig/recoMC/NoFieldRun1B.fcl
+++ b/JobConfig/recoMC/NoFieldRun1B.fcl
@@ -91,6 +91,12 @@ outputs.KinematicLineOutput.outputCommands: [
    "keep mu2e::KalSeeds_CosmicKKLine_*_*"
    ]
 
+physics.producers.SelectReco.TimeClusterCollections : [
+  "CalTimeClusterFinder",
+  "ProtonCalTimeClusterFinder",
+  "TZClusterFinder"
+]
+
 physics.RecoPath: [
       "CaloRecoDigiMaker",
       "CaloHitMaker",

--- a/JobConfig/recoMC/NoFieldRun1B.fcl
+++ b/JobConfig/recoMC/NoFieldRun1B.fcl
@@ -48,10 +48,29 @@ physics.producers.CalTimeClusterFinder : {
 physics.producers.LineFinder.TimeClusterCollection : "CalTimeClusterFinder"
 physics.producers.LineFinder.ComboHitCollection: "makePH"
 
+# Add proton reco
+physics.producers.ProtonCalTimeClusterFinder : {
+  @table::physics.producers.CalTimeClusterFinder
+  StrawEDepMin               : 0.002 # proton-like
+  StrawEDepMax               : 0.005
+}
+physics.producers.ProtonLineFinder : {
+  @table::physics.producers.LineFinder
+  TimeClusterCollection: "ProtonCalTimeClusterFinder"
+}
+physics.producers.ProtonKKLine : {
+  @table::physics.producers.KKLine
+}
+physics.producers.ProtonKKLine.ModuleSettings.CosmicTrackSeedCollections : [ "ProtonLineFinder" ]
+physics.producers.ProtonKKLine.ModuleSettings.FitParticle: 2212
+physics.producers.ProtonKKLine.ModuleSettings.SeedMomentum  : 400. # ~80 MeV KE
+physics.producers.SelectReco.KalSeedCollections : [ @sequence::physics.producers.SelectReco.KalSeedCollections, "ProtonKKLine" ]
+
 outputs.KinematicLineOutput.outputCommands: [
    @sequence::outputs.KinematicLineOutput.outputCommands,
    "keep mu2e::CosmicTrackSeeds_*_*_*",
-   "keep mu2e::TimeClusters_*_*_*"
+   "keep mu2e::TimeClusters_*_*_*",
+   "keep mu2e::KalSeeds_ProtonKKLine_*_*"
    ]
 
 physics.RecoPath: [
@@ -70,6 +89,9 @@ physics.RecoPath: [
       "TimeAndPhiClusterFinder",
       "LineFinder",
       "KKLine",
+      "ProtonCalTimeClusterFinder",
+      "ProtonLineFinder",
+      "ProtonKKLine",
       "SelectReco",
       "CaloHitTruthMatch",
       "CaloClusterTruthMatch",

--- a/JobConfig/recoMC/NoFieldRun1B.fcl
+++ b/JobConfig/recoMC/NoFieldRun1B.fcl
@@ -44,6 +44,9 @@ physics.producers.CalTimeClusterFinder : {
   CaloClusterCollectionLabel : "CaloClusterMaker"
 }
 
+# Only produce clusters associated with calo clusters
+physics.producers.TZClusterFinder.requireCCs : true
+
 # physics.producers.LineFinder.TimeClusterCollection : "TimeAndPhiClusterFinder"
 physics.producers.LineFinder.TimeClusterCollection : "CalTimeClusterFinder"
 physics.producers.LineFinder.ComboHitCollection: "makePH"
@@ -66,11 +69,26 @@ physics.producers.ProtonKKLine.ModuleSettings.FitParticle: 2212
 physics.producers.ProtonKKLine.ModuleSettings.SeedMomentum  : 400. # ~80 MeV KE
 physics.producers.SelectReco.KalSeedCollections : [ @sequence::physics.producers.SelectReco.KalSeedCollections, "ProtonKKLine" ]
 
+# Add cosmic muon reco
+physics.producers.CosmicLineFinder : {
+  @table::physics.producers.LineFinder
+  TimeClusterCollection: "TZClusterFinder"
+}
+physics.producers.CosmicKKLine : {
+  @table::physics.producers.KKLine
+}
+physics.producers.CosmicKKLine.ModuleSettings.CosmicTrackSeedCollections : [ "CosmicLineFinder" ]
+physics.producers.CosmicKKLine.ModuleSettings.FitParticle: 13
+physics.producers.CosmicKKLine.ModuleSettings.SeedMomentum  : 200.
+physics.producers.SelectReco.KalSeedCollections : [ @sequence::physics.producers.SelectReco.KalSeedCollections, "CosmicKKLine" ]
+
+# Final config
 outputs.KinematicLineOutput.outputCommands: [
    @sequence::outputs.KinematicLineOutput.outputCommands,
    "keep mu2e::CosmicTrackSeeds_*_*_*",
    "keep mu2e::TimeClusters_*_*_*",
-   "keep mu2e::KalSeeds_ProtonKKLine_*_*"
+   "keep mu2e::KalSeeds_ProtonKKLine_*_*",
+   "keep mu2e::KalSeeds_CosmicKKLine_*_*"
    ]
 
 physics.RecoPath: [
@@ -86,12 +104,15 @@ physics.RecoPath: [
       "CrvRecoPulses",
       "CrvCoincidenceClusterFinder",
       "CalTimeClusterFinder",
+      "ProtonCalTimeClusterFinder",
       "TimeAndPhiClusterFinder",
+      "TZClusterFinder",
       "LineFinder",
       "KKLine",
-      "ProtonCalTimeClusterFinder",
       "ProtonLineFinder",
       "ProtonKKLine",
+      "CosmicLineFinder",
+      "CosmicKKLine",
       "SelectReco",
       "CaloHitTruthMatch",
       "CaloClusterTruthMatch",

--- a/JobConfig/recoMC/prolog.fcl
+++ b/JobConfig/recoMC/prolog.fcl
@@ -30,6 +30,7 @@ Reconstruction.producers : {
     StrawDigiMCCollection : "compressDigiMCs"
     CrvDigiMCCollection : "compressDigiMCs"
     KalSeedCollections  : [ "KKDe", "KKDmu", "KKUe", "KKUmu", "KKLine", "KKCHmu" ]
+    TimeClusterCollections : [ ]
     VDSPCollection : "compressDigiMCs:virtualdetector"
   }
   # Compresion

--- a/Tests/Run1BReco.fcl
+++ b/Tests/Run1BReco.fcl
@@ -1,0 +1,7 @@
+#include "Production/JobConfig/recoMC/NoFieldRun1B.fcl"
+
+services.GeometryService.inputFile: "Offline/Mu2eG4/geom/geom_run1_b_v40.txt"
+services.DbService.nearestMatch: true
+services.DbService.purpose: "Sim_best"
+services.DbService.version: "v1_5"
+services.DbService.verbose : 2


### PR DESCRIPTION
This is the corresponding PR to Offline PR https://github.com/Mu2e/Offline/pull/1894. It adds proton and cosmic muon line reco sequences in addition to the normal stopping target electron line reconstruction. It also adds empty time cluster lists for nominal reco processing, but sets those used for line-fitting in Run 1B reco processing. I also added a test fcl for Run 1B reco to help, though it requires the Run 1B branch of Offline.