### PR TITLE
Proton tail configuration

### DIFF
--- a/JobConfig/pileup/prolog.fcl
+++ b/JobConfig/pileup/prolog.fcl
@@ -297,6 +297,7 @@ Pileup: {
     spectrum: {
       spectrumShape: tabulated
       spectrumFileName: "Offline/EventGenerator/data/neutronSpectrum.txt"
+      BinCenter : true
     }
   }
 

--- a/JobConfig/primary/MuCapNeutronTailCalo.fcl
+++ b/JobConfig/primary/MuCapNeutronTailCalo.fcl
@@ -7,4 +7,4 @@
 
 physics.producers.generate.decayProducts.czmin : 0.99
 physics.producers.generate.decayProducts.czmax : 1.
-outputs.PrimaryOutput.fileName: "dts.owner.MuCapNeutronCalo.version.sequencer.art"
+outputs.PrimaryOutput.fileName: "dts.owner.MuCapNeutronTailCalo.version.sequencer.art"

--- a/JobConfig/primary/MuCapProtonTail.fcl
+++ b/JobConfig/primary/MuCapProtonTail.fcl
@@ -1,0 +1,26 @@
+#
+# Generate high KE muon capture protons
+#
+# Original author: Michael MacKenzie, 2026
+#
+#include "Production/JobConfig/primary/TargetStopParticle.fcl"
+
+physics.producers.generate : {
+  module_type : SingleProcessGenerator
+  inputSimParticles: TargetStopResampler
+  stoppingTargetMaterial : "Al"
+  decayProducts :
+  {
+    tool_type : MuCapProtonGenerator
+    spectrumVariable : kineticEnergy
+    spectrum : {
+      spectrumShape : ejectedProtons
+      elow : 60. # Only simulate the high energy tail
+      nbins: 1000
+    }
+  }
+  verbosity : 0
+}
+
+physics.producers.FindMCPrimary.PrimaryProcess : "mu2eMuonCaptureAtRest"
+outputs.PrimaryOutput.fileName: "dts.owner.MuCapProtonTail.version.sequencer.art"

--- a/JobConfig/primary/MuCapProtonTailCalo.fcl
+++ b/JobConfig/primary/MuCapProtonTailCalo.fcl
@@ -1,0 +1,10 @@
+#
+# Generate high energy muon capture protons, aimed at the calorimeter
+#
+# Original author: Michael MacKenzie, 2026
+#
+#include "Production/JobConfig/primary/MuCapProtonTail.fcl"
+
+physics.producers.generate.decayProducts.czmin : 0.99
+physics.producers.generate.decayProducts.czmax : 1.
+outputs.PrimaryOutput.fileName: "dts.owner.MuCapProtonTailCalo.version.sequencer.art"

--- a/Tests/MuCapProtonTail.fcl
+++ b/Tests/MuCapProtonTail.fcl
@@ -1,0 +1,4 @@
+#include "Production/JobConfig/primary/MuCapProtonTailCalo.fcl"
+#include "Production/Tests/MuonStopConfig.fcl"
+
+services.TFileService.fileName: "nts.owner.test.version.sequencer.root"


### PR DESCRIPTION
This adds fcl for high KE proton tail simulations that are needed for Run 1B analysis. This is associated with Offline PR https://github.com/Mu2e/Offline/pull/1898. This also fixes the neutron pileup spectrum configuration, and validation shows the muon proton and neutron spectra correctly report unit energy spectrum fractions for the pileup job.