### PR TITLE
Remove filter on good tracks

### DIFF
--- a/JobConfig/reco/Extracted.fcl
+++ b/JobConfig/reco/Extracted.fcl
@@ -5,3 +5,10 @@
 services.GeometryService.inputFile: "Offline/Mu2eG4/geom/geom_common_extracted.txt"
 physics.producers.KKLine.ModuleSettings.SampleSurfaces : [ @sequence::physics.producers.KKLine.ModuleSettings.SampleSurfaces, "TCRV" ] #temporary until extrapolation is working
 #include "Offline/CRVReco/fcl/epilog_extracted.fcl"
+
+# Disable KL filtering so track-less events are kept (needed for CRV
+# efficiency / tag-and-probe; matches OnSpill LHFilter disable).
+physics.filters.KLFilter : {
+  module_type : FixedFilter
+  ReturnValue : true
+}

--- a/JobConfig/recoMC/Extracted.fcl
+++ b/JobConfig/recoMC/Extracted.fcl
@@ -5,3 +5,10 @@
 services.GeometryService.inputFile: "Offline/Mu2eG4/geom/geom_common_extracted.txt"
 physics.producers.KKLine.ModuleSettings.SampleSurfaces : [ @sequence::physics.producers.KKLine.ModuleSettings.SampleSurfaces, "TCRV" ] #temporary until extrapolation is working
 #include "Offline/CRVReco/fcl/epilog_extracted.fcl"
+
+# Disable KL filtering so track-less events are kept (needed for CRV
+# efficiency / tag-and-probe; matches OnSpill LHFilter disable).
+physics.filters.KLFilter : {
+  module_type : FixedFilter
+  ReturnValue : true
+}


### PR DESCRIPTION
to keep non-through-going muon cosmics in the mcs file. Needed for CRV efficiency studies.