### PR TITLE
Added IPAEndRingStops to track stopped muons in the MuBeamResampler.fcl

### DIFF
--- a/JobConfig/pileup/MuBeamResampler.fcl
+++ b/JobConfig/pileup/MuBeamResampler.fcl
@@ -38,8 +38,8 @@ physics: {
   IPAEndRingStopPath : [ @sequence::Pileup.beamResamplerSequence, @sequence::Common.g4Sequence, IPAEndRingMuonFinder, IPAEndRingStopFilter, compressPVIPAEndRingStops]
   flashPath : [ @sequence::Pileup.beamResamplerSequence, @sequence::Common.g4Sequence, @sequence::Pileup.flashSequence, @sequence::Pileup.DetStepSequence ]
   earlyFlashPath : [ @sequence::Pileup.beamResamplerSequence, @sequence::Common.g4Sequence, @sequence::Pileup.flashSequence, @sequence::Pileup.EarlyDetStepSequence ]
-  trigger_paths: [ flashPath, earlyFlashPath, targetStopPath, polyStopPath, IPAStopPath, IPAEndRingStopPath ]
-  outPath : [ FlashOutput, EarlyFlashOutput, TargetStopOutput, PolyStopOutput, IPAStopOutput, IPAEndRingStopOutput ]
+  trigger_paths: [ flashPath, earlyFlashPath, targetStopPath, polyStopPath, IPAStopPath ]
+  outPath : [ FlashOutput, EarlyFlashOutput, TargetStopOutput, PolyStopOutput, IPAStopOutput ]
   end_paths: [outPath]
 }
 
@@ -72,12 +72,12 @@ outputs: {
   }
 
   IPAEndRingStopOutput : {
-    module_type : RootOutput
+    module_type: RootOutput
     outputCommands: [ "drop *_*_*_*",
       @sequence::Pileup.SimKeptProducts
      ]
-     SelectEvents : [IPAEndRingStopPath]
-     fileName : "sim.owner.IPAEndRingStops.version.sequencer.art"
+     SelectEvents: [IPAEndRingStopPath]
+     fileName: "sim.owner.IPAEndRingStops.version.sequencer.art"
   }
 
   FlashOutput : {

--- a/JobConfig/pileup/MuBeamResampler.fcl
+++ b/JobConfig/pileup/MuBeamResampler.fcl
@@ -35,10 +35,11 @@ physics: {
   targetStopPath : [ @sequence::Pileup.beamResamplerSequence, @sequence::Common.g4Sequence, TargetStopPrescaleFilter, TargetMuonFinder, TargetStopFilter, compressPVTargetStops]
   polyStopPath : [ @sequence::Pileup.beamResamplerSequence, @sequence::Common.g4Sequence, PolyStopPrescaleFilter, PolyMuonFinder, PolyStopFilter, compressPVPolyStops]
   IPAStopPath : [ @sequence::Pileup.beamResamplerSequence, @sequence::Common.g4Sequence, IPAMuonFinder, IPAStopFilter, compressPVIPAStops]
+  IPAEndRingStopPath : [ @sequence::Pileup.beamResamplerSequence, @sequence::Common.g4Sequence, IPAEndRingMuonFinder, IPAEndRingStopFilter, compressPVIPAEndRingStops]
   flashPath : [ @sequence::Pileup.beamResamplerSequence, @sequence::Common.g4Sequence, @sequence::Pileup.flashSequence, @sequence::Pileup.DetStepSequence ]
   earlyFlashPath : [ @sequence::Pileup.beamResamplerSequence, @sequence::Common.g4Sequence, @sequence::Pileup.flashSequence, @sequence::Pileup.EarlyDetStepSequence ]
-  trigger_paths: [ flashPath, earlyFlashPath, targetStopPath, polyStopPath, IPAStopPath ]
-  outPath : [ FlashOutput, EarlyFlashOutput, TargetStopOutput, PolyStopOutput, IPAStopOutput ]
+  trigger_paths: [ flashPath, earlyFlashPath, targetStopPath, polyStopPath, IPAStopPath, IPAEndRingStopPath ]
+  outPath : [ FlashOutput, EarlyFlashOutput, TargetStopOutput, PolyStopOutput, IPAStopOutput, IPAEndRingStopOutput ]
   end_paths: [outPath]
 }
 
@@ -68,6 +69,15 @@ outputs: {
     ]
     SelectEvents: [IPAStopPath]
     fileName : "sim.owner.IPAStops.version.sequencer.art"
+  }
+
+  IPAEndRingStopOutput : {
+    module_type : RootOutput
+    outputCommands: [ "drop *_*_*_*",
+      @sequence::Pileup.SimKeptProducts
+     ]
+     SelectEvents : [IPAEndRingStopPath]
+     fileName : "sim.owner.IPAEndRingStops.version.sequencer.art"
   }
 
   FlashOutput : {

--- a/JobConfig/pileup/MuBeamResampler.fcl
+++ b/JobConfig/pileup/MuBeamResampler.fcl
@@ -75,9 +75,9 @@ outputs: {
     module_type: RootOutput
     outputCommands: [ "drop *_*_*_*",
       @sequence::Pileup.SimKeptProducts
-     ]
-     SelectEvents: [IPAEndRingStopPath]
-     fileName: "sim.owner.IPAEndRingStops.version.sequencer.art"
+    ]
+    SelectEvents: [IPAEndRingStopPath]
+    fileName: "sim.owner.IPAEndRingStops.version.sequencer.art"
   }
 
   FlashOutput : {

--- a/JobConfig/pileup/prolog.fcl
+++ b/JobConfig/pileup/prolog.fcl
@@ -83,6 +83,16 @@ Pileup: {
       verbosityLevel: 1
     }
 
+    IPAEndRingMuonFinder : {
+      module_type : StoppedParticlesFinder
+      particleInput : "g4run"
+      useEventLevelVolumeInfo: true
+      physVolInfoInput: "g4run:eventlevel"
+      stoppingMaterial : "IPAPolystyrene"
+      particleTypes : [ 13, -13 ]
+      verbosityLevel: 1
+    }
+
     stoppedMuonDaughters: {
       module_type: SimParticleDaughterSelector
       particleInput: "TargetMuonFinder"
@@ -122,12 +132,18 @@ Pileup: {
       particleInputs : [ "TargetPiStopFilter" ]
     }
 
-
     compressPVIPAStops: {
       module_type: CompressPhysicalVolumes
       volumesInput : "g4run"
       hitInputs : []
       particleInputs : [ "IPAStopFilter" ]
+    }
+
+    compressPVIPAEndRingStops: {
+      module_type: CompressPhysicalVolumes
+      volumesInput : "g4run"
+      hitInputs : []
+      particleInputs : [ "IPAEndRingStopFilter" ]
     }
 
     protonTimeOffset : @local::CommonMC.protonTimeOffset
@@ -177,12 +193,18 @@ Pileup: {
       mainSPPtrInputs: [ "TargetPionFinder" ]
     }
 
-
     IPAStopFilter: {
       module_type: FilterG4Out
       mainHitInputs: []
       extraHitInputs: [ "g4run:virtualdetector" ]
       mainSPPtrInputs: [ "IPAMuonFinder" ]
+    }
+
+    IPAEndRingStopFilter: {
+      module_type: FilterG4Out
+      mainHitInputs: []
+      extraHitInputs: [ "g4run:virtualdetector" ]
+      mainSPPtrInputs: [ "IPAEndRingMuonFinder" ]
     }
 
     FlashFilter: {
@@ -210,7 +232,8 @@ Pileup: {
       wrapFiles: true
       mu2e: {
         writeEventIDs : true
-        MaxEventsToSkip: @nil
+        //MaxEventsToSkip: @nil
+        MaxEventsToSkip: 0
         debugLevel : 0
         products: {
           genParticleMixer: { mixingMap: [ [ "generate", "" ] ] }
@@ -235,7 +258,8 @@ Pileup: {
       wrapFiles: true
       mu2e: {
         writeEventIDs : true
-        MaxEventsToSkip:  @nil
+        //MaxEventsToSkip:  @nil
+        MaxEventsToSkip: 0
         debugLevel : 0
         products: {
           genParticleMixer: { mixingMap: [ [ "generate", "" ] ] }

--- a/JobConfig/pileup/prolog.fcl
+++ b/JobConfig/pileup/prolog.fcl
@@ -232,7 +232,7 @@ Pileup: {
       wrapFiles: true
       mu2e: {
         writeEventIDs : true
-        MaxEventsToSkip: @nill
+        MaxEventsToSkip: @nil
         debugLevel : 0
         products: {
           genParticleMixer: { mixingMap: [ [ "generate", "" ] ] }

--- a/JobConfig/pileup/prolog.fcl
+++ b/JobConfig/pileup/prolog.fcl
@@ -232,7 +232,6 @@ Pileup: {
       wrapFiles: true
       mu2e: {
         writeEventIDs : true
-        //MaxEventsToSkip: @nil
         MaxEventsToSkip: 0
         debugLevel : 0
         products: {
@@ -258,8 +257,7 @@ Pileup: {
       wrapFiles: true
       mu2e: {
         writeEventIDs : true
-        //MaxEventsToSkip:  @nil
-        MaxEventsToSkip: 0
+        MaxEventsToSkip:  @nil
         debugLevel : 0
         products: {
           genParticleMixer: { mixingMap: [ [ "generate", "" ] ] }

--- a/JobConfig/pileup/prolog.fcl
+++ b/JobConfig/pileup/prolog.fcl
@@ -232,7 +232,7 @@ Pileup: {
       wrapFiles: true
       mu2e: {
         writeEventIDs : true
-        MaxEventsToSkip: 0
+        MaxEventsToSkip: @nill
         debugLevel : 0
         products: {
           genParticleMixer: { mixingMap: [ [ "generate", "" ] ] }


### PR DESCRIPTION
- Dependent on Offline/Mu2eG4/geom/protonAbsorber_cylindrical_v05.txt
- geom_run1_a.txt shuold move to v05 to reflect correct IPAEndRing dimensions
- Currently EndRingPath is disabled from trigger and out paths in the fcl file
	- To enable paths add IPAEndRingStopPath to the end of physics.trigger_paths and IPAEndRingStopOutput to physics.outPath