### PR TITLE
fix(recoMC): default NoFieldRun1B to the v40 Run1B geometry

### DIFF
--- a/JobConfig/recoMC/NoFieldRun1B.fcl
+++ b/JobConfig/recoMC/NoFieldRun1B.fcl
@@ -1,8 +1,13 @@
 #
-# Extracted = NoField with shifted geometry
+# Run1B reconstruction with no solenoid field: straight-line tracking with
+# the extracted-position CRV configuration.
+#
+# The geometry below is the Run1B production geometry.  Every production
+# caller overrides services.GeometryService.inputFile explicitly, so this
+# default applies to bare running only.
 #
 #include "Production/JobConfig/recoMC/NoField.fcl"
-services.GeometryService.inputFile  : "Offline/Mu2eG4/geom/geom_run1_b_v01.txt"
+services.GeometryService.inputFile  : "Offline/Mu2eG4/geom/geom_run1_b_v40.txt"
 physics.producers.KKLine.ModuleSettings.SampleSurfaces : [ @sequence::physics.producers.KKLine.ModuleSettings.SampleSurfaces, "TCRV" ] #temporary until extrapolation is working
 #include "Offline/CRVReco/fcl/epilog_extracted.fcl"
 


### PR DESCRIPTION
NoFieldRun1B.fcl defaulted to geom_run1_b_v01.txt, a superseded geometry that replaced the 37-foil stopping target with a single 600 mm disk and moved the tracker and calorimeter to the extracted positions. The Run1B production geometry is geom_run1_b_v40.txt, which inherits geom_run1_a.txt untouched and adds the two-piece aluminium assembly at the TS5 face.

No production job changes behaviour. Every caller sets services.GeometryService.inputFile explicitly: the live prodtools template templates/Run1B/reco.json and Tests/Run1BReco.fcl both select v40, and the frozen Run1Baa-Bai entries in prodtools data/Run1B/reco.json pin v01, v03 and v06 so they keep reproducing their original campaigns. The default therefore governs only bare invocation, where it now matches what Run1Ban and Run1Bap actually run.

The header comment described the v01 layout and no longer applied.

Requires Mu2e/Offline#1923, which adds geom_run1_b_v40.txt to Offline main.