### PR TITLE
feat(mixing): add OneBB1500W preset and 1BB1500W beam constants

### DIFF
--- a/JobConfig/ensemble/python/constants.py
+++ b/JobConfig/ensemble/python/constants.py
@@ -34,3 +34,24 @@ ONEBB_POT_PER_CYCLE=4e12 # protons per 1.33 s cycle in one-bunch mode
 TWOBB_POT_PER_CYCLE=8e12 # protons per 1.4 s cycle in two-bunch mode
 ONEBB_CYCLE = 1.33 # seconds per cycle in one-bunch mode
 TWOBB_CYCLE = 1.4 # seconds per cycle in two-bunch mode
+
+# One booster batch at a reduced intensity of 1500 W, as used by the
+# Run1B campaigns. Matches JobConfig/mixing/OneBB1500W.fcl. Same
+# accelerator mode as 1BB, so it takes ONEBB_DF and ONEBB_CYCLE; only
+# the intensity differs.
+#
+# Protons per spill follow from POT per cycle divided by the number of
+# 1695 ns spills that fit in the onspill fraction of a cycle:
+#
+#   mode     | power    | POT/cycle / (DF x cycle / SPILL)     = protons/spill
+#   ---------|----------|--------------------------------------|--------------
+#   1BB1500W | 1.500 kW | 1.556e12 / (0.323 x 1.33 / 1.695e-6) = 6.141e6
+#   1BB      | 3.855 kW |    4e12 / (0.323 x 1.33 / 1.695e-6)  = 1.578e7
+#   2BB      | 7.324 kW |    8e12 / (0.246 x 1.40 / 1.695e-6)  = 3.937e7
+#
+# Power is POT_PER_CYCLE * 8 GeV / CYCLE, so it depends on the cycle
+# time, not on the duty factor. Note 2BB delivers double the protons in
+# a shorter spill (0.344 s against 0.430 s), which is why 1BB and 2BB
+# are not a factor of two apart in protons per spill.
+ONEBB1500W_POT_PER_CYCLE = 1.556e12 # protons per 1.33 s cycle at 1500 W
+ONEBB1500W_PROTONS_PER_SPILL = 6.14e6 # protons per 1695 ns spill at 1500 W

--- a/JobConfig/mixing/OneBB1500W.fcl
+++ b/JobConfig/mixing/OneBB1500W.fcl
@@ -1,0 +1,11 @@
+#
+# One booster batch at reduced intensity: 1500 W.
+#
+# 1.5565e12 POT per 1.33 s cycle, which is 0.389 of a full 4e12 batch,
+# spread over the 253445 microbunches of the 0.4296 s spill (1BB duty
+# factor 0.323).  Accelerator parameters are those in
+# JobConfig/ensemble/python/constants.py.
+#
+#include "Production/JobConfig/mixing/OneBB.fcl"
+physics.producers.PBISim.extendedMean: 6.14e6 # 1500 W
+physics.producers.PBISim.cutMax: 36.8e6  # truncate the tail at 6 times the mean


### PR DESCRIPTION
Adds a one-booster-batch beam preset at 1500 W, and the Run1B constants it
derives from.

## Why

The mixing presets cover full 1BB (1.58e7 protons/spill), full 2BB (3.93e7) and
1% of a single batch pulse (1.58e5). Run1B runs one booster batch at reduced
intensity, which is none of these, so every Run1B campaign has carried a bare
`extendedMean` override in its prodtools entry with no record of where the
number came from. Reconstructing it took a full pass through the accelerator
parameters.

## The derivation

Protons per spill is POT per cycle divided by the number of 1695 ns spills that
fit in the onspill fraction of a cycle:

| mode | power | POT/cycle / (DF × cycle / SPILL) | = protons/spill |
|---|---|---|---|
| 1BB1500W | 1.500 kW | 1.556e12 / (0.323 × 1.33 / 1.695e-6) | 6.141e6 |
| 1BB | 3.855 kW | 4e12 / (0.323 × 1.33 / 1.695e-6) | 1.578e7 |
| 2BB | 7.324 kW | 8e12 / (0.246 × 1.40 / 1.695e-6) | 3.937e7 |

This reproduces the two existing presets to their quoted precision, which is
what establishes that the relation is the right one. It also explains why 1BB
and 2BB are not a factor of two apart in protons per spill despite being a
factor of two in protons: 2BB delivers double the protons in a *shorter* spill,
0.344 s against 0.430 s. Power depends on POT/cycle and cycle time only — the
duty factor cancels.

`cutMax` follows the 6× convention of the other presets. `OneBB1500W.fcl`
includes `OneBB.fcl` rather than restating `SDF`, so the lognormal width stays
defined in one place and the file does not depend on include order.

## Normalisation gap, documented but not closed

`ensemble/python/constants.py` carried only 1BB and 2BB. Normalising Run1B with
`run_mode='1BB'` assumes 1.58e7 protons/spill where the campaigns actually mix
5.92e6 — an overestimate of POT by 2.7×.

This PR adds `ONEBB1500W_DF`, `ONEBB1500W_CYCLE`, `ONEBB1500W_POT_PER_CYCLE`
and `ONEBB1500W_PROTONS_PER_SPILL` — named for the beam rather than the
campaign, following `ONEBB_`/`TWOBB_`, with `'1BB1500W'` as the natural run mode
string — but **does not wire them in**: `get_duty_factor()` and `get_pot()`
still branch on `'1BB'` and `'2BB'` only, so this normalisation continues to
require the `custom` method. Making it a first-class run mode touches four
branch sites across two functions and is better reviewed on its own. Worth
folding into that change: `get_duty_factor()` currently *fails open*, returning
the 1BB duty factor for any unrecognised mode with its warning commented out,
while `get_pot()` raises.

## Effect on existing jobs

None. No existing fcl or campaign entry includes the new file, and nothing reads
the new constants. Verified: all three modes reproduce their stated
protons-per-spill from the constants as imported (Run1B −0.010%, 1BB −0.111%,
2BB +0.185%; the two existing figures are the rounded values the presets use).
