### PR TITLE
Calo DTS cluster filtering in mixing

### DIFF
--- a/JobConfig/mixing/NoPrimary.fcl
+++ b/JobConfig/mixing/NoPrimary.fcl
@@ -1,11 +1,11 @@
 #
-# configuration for NoPrimary: in this case, Untriggered selection should be wide open (null prescaler)
+# configuration for NoPrimary: in this case, Untriggered selection should be wide open (null prescaler) except for digitization success
 #
 physics.filters.Triggerable : {
   module_type : Prescaler
   prescaleFactor : 1
   prescaleOffset : 0
 }
-# turn off any filtering for triggerable output stream
+# turn off any filtering for triggerable output stream, other than successful digitization
 outputs.Output.RejectEvents : [ ]
 outputs.Output.SelectEvents : [ DigitizePath ] # Don't save events that fail digitization

--- a/JobConfig/mixing/NoPrimary.fcl
+++ b/JobConfig/mixing/NoPrimary.fcl
@@ -7,5 +7,5 @@ physics.filters.Triggerable : {
   prescaleOffset : 0
 }
 # turn off any filtering for triggerable output stream
-outputs.Output.RejectEvents : []
-outputs.Output.SelectEvents : []
+outputs.Output.RejectEvents : [ ]
+outputs.Output.SelectEvents : [ DigitizePath ] # Don't save events that fail digitization

--- a/JobConfig/mixing/prolog.fcl
+++ b/JobConfig/mixing/prolog.fcl
@@ -81,13 +81,26 @@ Mixing : {
       ReturnValue : true
     }
 
+    CaloDtsClusterFilter : {
+      module_type : CaloDtsClusterFilter
+      CaloShowerSteps        : ["compressDetStepMCs", "MuStopPileupMixer", "EleBeamFlashMixer", "MuBeamFlashMixer", "NeutralsFlashMixer"]
+      MinimumStepEnergy      : 0.
+      MinimumStepTime        : 400.
+      MaximumStepTime        : 1.e6 # can't do fmod(time, 1695) accurately at high times
+      MinimumClusterEnergy   : 50.
+      TimeWindow             : 100.
+      SpaceWindow            : 80.
+      NullFilter             : true # Default to off
+      DiagLevel              : 0
+    }
+
   }
   StepMixSequence : [  MuStopPileupMixer, EleBeamFlashMixer, MuBeamFlashMixer, NeutralsFlashMixer ]
   StepFilterSequence : [ MuStopPileupFilter, EleBeamFlashFilter, MuBeamFlashFilter, NeutralsFlashFilter ]
   # when mixing early events the intensity must be scaled down
   EarlyReductionFactor : 1.0e-2
 }
-Mixing.PileupMixSequence : [ PBISim, DTSFilter, @sequence::Mixing.StepMixSequence, @sequence::Mixing.StepFilterSequence ]
+Mixing.PileupMixSequence : [ PBISim, DTSFilter, @sequence::Mixing.StepMixSequence, @sequence::Mixing.StepFilterSequence, CaloDtsClusterFilter ]
 Mixing.MixSequence : [ @sequence::Mixing.PileupMixSequence, @sequence::Digitize.DigitizeSequence ]
 # override the Trigger 'PrepareDigis' sequence; the mixers must preceed the digi making
 TrigRecoSequences.cfoDataGen: [ @sequence::Mixing.PileupMixSequence, @sequence::Digitize.DigitizeSequence, ProcessCFOData ]

--- a/JobConfig/mixing/prolog.fcl
+++ b/JobConfig/mixing/prolog.fcl
@@ -84,12 +84,12 @@ Mixing : {
     CaloDtsClusterFilter : {
       module_type : CaloDtsClusterFilter
       CaloShowerSteps        : ["compressDetStepMCs", "MuStopPileupMixer", "EleBeamFlashMixer", "MuBeamFlashMixer", "NeutralsFlashMixer"]
-      MinimumStepEnergy      : 0.
-      MinimumStepTime        : 400.
-      MaximumStepTime        : 1.e6 # can't do fmod(time, 1695) accurately at high times
-      MinimumClusterEnergy   : 50.
-      TimeWindow             : 100.
-      SpaceWindow            : 80.
+      MinimumStepEnergy      : 0.   # MeV
+      MinimumStepTime        : 400. # ns
+      MaximumStepTime        : 1.e6 # ns, can't do fmod(time, 1695) accurately at high times
+      MinimumClusterEnergy   : 50.  # MeV
+      TimeWindow             : 100. # ns
+      SpaceWindow            : 80.  # mm
       NullFilter             : true # Default to off
       DiagLevel              : 0
     }


### PR DESCRIPTION
Add the calo DTS cluster filter module to the mixing workflow, off by default. In Run 1B we can turn this on for the No Primary mixing to only digitize and save events that have high energy deposits. This will allow us to simulate higher statistics without significant CPU or data output increases.