### PR TITLE
feat(config): add Run1B.fcl, a single detector-configuration epilog

### DIFF
--- a/JobConfig/common/Run1B.fcl
+++ b/JobConfig/common/Run1B.fcl
@@ -1,0 +1,15 @@
+#
+# Detector configuration for Run 1B: geometry and field, set together.
+#
+# Include LAST, after the job's own epilogs, so that it wins:
+#
+#   #include "Production/JobConfig/common/Run1B.fcl"
+#
+# bfgeom_DSOff is the detector solenoid off with the PS and TS maps still
+# present and unscaled. It is not bfgeom_no_field, which is zero everywhere.
+#
+services.GeometryService.inputFile  : "Offline/Mu2eG4/geom/geom_run1_b_v40.txt"
+services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_DSOff.txt"
+
+# DS-on Run 1B uses geom_run1_b_ds_on_v40.txt with the normal field.
+# Trigger menu and digitizationEnd stay in digitize/OnSpill_run1b_epilog.fcl.


### PR DESCRIPTION
Run 1B is currently selected by setting two keys in two different ways. JobConfig/common/epilog.fcl points GeometryService.inputFile at geom_common.txt, an indirection file a release can repoint; bFieldFile has no such indirection and comes from Offline standardServices.fcl, so each job sets it directly if it needs something else.

Splitting one choice across two mechanisms has already produced wrong configurations. The live Run1Ban and Run1Bap Musings repoint geom_common.txt to geom_run1_b_v01.txt -- superseded, not what Run 1B runs -- and leave the field at bfgeom_v01.txt with the DS on. Run 1B production is v40 with bfgeom_DSOff.txt. Nothing broke only because the prodtools templates set both keys explicitly on every entry.

This file makes the pair one include. Values are copied from templates/Run1B/digi.json and templates/Run1B/reco.json, which agree. Included last it beats epilog.fcl (verified with fhicl-dump against both digitize/OnSpill.fcl and reco/OnSpill.fcl).

Scope is detector configuration only. Trigger menu and digitizationEnd stay in digitize/OnSpill_run1b_epilog.fcl because they name producers that exist only in digitize jobs; DbService purpose and version stay per entry because the calibration campaign moves independently.

Nothing includes this file yet, so no existing job changes behaviour.